### PR TITLE
Capture source attribution, in-app history preview, and chrome/toast fixes

### DIFF
--- a/src/OddSnap.Tests/AppSettingsTests.cs
+++ b/src/OddSnap.Tests/AppSettingsTests.cs
@@ -164,10 +164,20 @@ public class AppSettingsTests
     }
 
     [Fact]
-    public void DefaultPinnedToolbarIds_AreExactlyCaptureTools()
+    public void DefaultPinnedToolbarIds_AreCaptureToolsPlusSelect()
     {
-        var expected = ToolDef.AllTools.Where(t => t.Group == 0).Select(t => t.Id).ToList();
+        // Select is pinned because it is the only way to move, resize or delete an annotation.
+        var expected = ToolDef.AllTools.Where(t => t.Group == 0).Select(t => t.Id)
+            .Append("select")
+            .ToList();
         Assert.Equal(expected, ToolDef.DefaultPinnedToolbarIds());
+    }
+
+    [Fact]
+    public void DefaultPinnedToolbarIds_AreAllKnownToolbarItems()
+    {
+        var known = ToolDef.AllToolbarItems().Select(t => t.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        Assert.All(ToolDef.DefaultPinnedToolbarIds(), id => Assert.Contains(id, known));
     }
 
     [Fact]

--- a/src/OddSnap.Tests/CaptureSourceAppTests.cs
+++ b/src/OddSnap.Tests/CaptureSourceAppTests.cs
@@ -1,0 +1,28 @@
+using OddSnap.Helpers;
+using Xunit;
+
+namespace OddSnap.Tests;
+
+public class CaptureSourceAppTests
+{
+    [Theory]
+    [InlineData("Discord", "Discord")]
+    [InlineData("Task Manager", "Task-Manager")]
+    [InlineData("Visual Studio: Code", "Visual-Studio-Code")]
+    [InlineData("  Notepad  ", "Notepad")]
+    [InlineData("Foo/Bar\\Baz", "FooBarBaz")]
+    public void SanitizeForFileName_ProducesFileSafeNames(string input, string expected)
+    {
+        Assert.Equal(expected, CaptureSourceApp.SanitizeForFileName(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("***")]
+    public void SanitizeForFileName_ReturnsNullWhenNothingUsableRemains(string? input)
+    {
+        Assert.Null(CaptureSourceApp.SanitizeForFileName(input));
+    }
+}

--- a/src/OddSnap.Tests/FileNameTemplateTests.cs
+++ b/src/OddSnap.Tests/FileNameTemplateTests.cs
@@ -122,6 +122,46 @@ public class FileNameTemplateTests
     }
 
     [Fact]
+    public void FormatExample_AppToken_ExpandsToSourceApp()
+    {
+        Assert.Equal("shot_Discord", FileNameTemplate.FormatExample("shot_{app}", "Discord", appendSourceApp: false));
+    }
+
+    [Fact]
+    public void FormatExample_AppToken_CollapsesWhenSourceAppIsUnknown()
+    {
+        Assert.Equal("shot", FileNameTemplate.FormatExample("shot_{app}", null, appendSourceApp: false));
+    }
+
+    [Fact]
+    public void FormatExample_AppendSourceApp_AppendsWhenTemplateHasNoAppToken()
+    {
+        Assert.Equal(
+            "2026-04-05-14-30-52-a3f1_Task-Manager",
+            FileNameTemplate.FormatExample(FileNameTemplate.DefaultTemplate, "Task Manager", appendSourceApp: true));
+    }
+
+    [Fact]
+    public void FormatExample_AppendSourceApp_DoesNotDuplicateExplicitAppToken()
+    {
+        Assert.Equal("Discord_shot", FileNameTemplate.FormatExample("{app}_shot", "Discord", appendSourceApp: true));
+    }
+
+    [Fact]
+    public void FormatExample_AppendSourceApp_IsANoOpWithoutASourceApp()
+    {
+        Assert.Equal(
+            FileNameTemplate.FormatExample(FileNameTemplate.DefaultTemplate),
+            FileNameTemplate.FormatExample(FileNameTemplate.DefaultTemplate, null, appendSourceApp: true));
+    }
+
+    [Fact]
+    public void FormatExample_AppToken_SanitizesUnsafeSourceAppCharacters()
+    {
+        Assert.Equal("shot_Visual-Studio-Code", FileNameTemplate.FormatExample("shot_{app}", "Visual Studio: Code", appendSourceApp: false));
+    }
+
+    [Fact]
     public void Presets_AllRenderToNonEmptyNames()
     {
         Assert.NotEmpty(FileNameTemplate.Presets);

--- a/src/OddSnap.Tests/ToastPreviewLayoutTests.cs
+++ b/src/OddSnap.Tests/ToastPreviewLayoutTests.cs
@@ -1,0 +1,101 @@
+using OddSnap.UI;
+using Xunit;
+
+namespace OddSnap.Tests;
+
+/// <summary>
+/// Image-only toasts must take the shape of the capture. A narrow strip used to be forced into a
+/// fixed 280x176 box, which showed as a border around the image.
+/// </summary>
+public class ToastPreviewLayoutTests
+{
+    private const int MaxWidth = 332;
+    private const int MaxHeight = 220;
+
+    // Smallest toast that still leaves room for the 40px overlay buttons in its corners.
+    private const int ButtonSafeWidth = 152;
+    private const int ButtonSafeHeight = 100;
+
+    [Theory]
+    [InlineData(1920, 1080)] // widescreen
+    [InlineData(800, 600)]   // 4:3
+    [InlineData(1000, 500)]  // wide
+    [InlineData(700, 900)]   // tall
+    [InlineData(600, 600)]   // square
+    // Ratios here are all moderate enough that the button-safe minimums don't kick in; more extreme
+    // strips are deliberately padded (see Layout_AlwaysLeavesRoomForTheOverlayButtons).
+    public void Layout_PreservesAspectRatio(int width, int height)
+    {
+        var (w, h, framed) = ToastWindow.ComputeImageOnlyPreviewLayout(width, height);
+
+        Assert.False(framed);
+        var sourceAspect = width / (double)height;
+        var layoutAspect = w / (double)h;
+        // Integer rounding of the final size allows a little drift.
+        Assert.InRange(layoutAspect, sourceAspect * 0.94, sourceAspect * 1.06);
+    }
+
+    [Theory]
+    [InlineData(1920, 1080)]
+    [InlineData(300, 1000)]
+    [InlineData(40, 40)]
+    [InlineData(4000, 2000)]
+    public void Layout_NeverExceedsTheToastBox(int width, int height)
+    {
+        var (w, h, _) = ToastWindow.ComputeImageOnlyPreviewLayout(width, height);
+
+        Assert.InRange(w, 1, MaxWidth);
+        Assert.InRange(h, 1, MaxHeight);
+    }
+
+    [Fact]
+    public void Layout_WideCaptureFillsTheToastWidth()
+    {
+        // The case that regressed: a wide capture used to come back as a fixed 280x176 frame.
+        var (w, _, _) = ToastWindow.ComputeImageOnlyPreviewLayout(1200, 500);
+
+        Assert.Equal(MaxWidth, w);
+    }
+
+    [Theory]
+    [InlineData(1200, 200)]  // wide strip
+    [InlineData(200, 1200)]  // tall strip
+    [InlineData(4000, 20)]   // extreme sliver
+    [InlineData(20, 4000)]
+    public void Layout_AlwaysLeavesRoomForTheOverlayButtons(int width, int height)
+    {
+        var (w, h, _) = ToastWindow.ComputeImageOnlyPreviewLayout(width, height);
+
+        Assert.True(w >= ButtonSafeWidth, $"width {w} is too narrow for the overlay buttons");
+        Assert.True(h >= ButtonSafeHeight, $"height {h} is too short for the overlay buttons");
+    }
+
+    [Fact]
+    public void Layout_MarksPaddedStripsAsFramed()
+    {
+        // Padding to the button-safe size means the image no longer fills the toast edge to edge.
+        var (_, _, framed) = ToastWindow.ComputeImageOnlyPreviewLayout(4000, 20);
+
+        Assert.True(framed);
+    }
+
+    [Fact]
+    public void Layout_SmallCaptureIsNotUpscaledIntoMush()
+    {
+        var (w, h, _) = ToastWindow.ComputeImageOnlyPreviewLayout(80, 60);
+
+        Assert.True(w <= 80 * 2);
+        Assert.True(h <= 60 * 2);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(-5, 10)]
+    public void Layout_HandlesDegenerateSizes(int width, int height)
+    {
+        var (w, h, _) = ToastWindow.ComputeImageOnlyPreviewLayout(width, height);
+
+        Assert.True(w >= 1);
+        Assert.True(h >= 1);
+    }
+}

--- a/src/OddSnap/App.xaml
+++ b/src/OddSnap/App.xaml
@@ -85,7 +85,7 @@
         </Style>
 
         <Style x:Key="OddSnapTitleCloseButton" TargetType="Border" BasedOn="{StaticResource OddSnapTitleButton}">
-            <Setter Property="CornerRadius" Value="0,11,0,0"/>
+            <Setter Property="CornerRadius" Value="{DynamicResource OddSnapTitleCloseCornerRadius}"/>
         </Style>
 
         <Style x:Key="OddSnapTitleButtonIcon" TargetType="Image">

--- a/src/OddSnap/App/App.Capture.Handlers.cs
+++ b/src/OddSnap/App/App.Capture.Handlers.cs
@@ -15,9 +15,10 @@ public partial class App
     private void HandleCaptureResult(Bitmap result, bool useAiRedirect = false)
     {
         var settings = _settingsService!.Settings;
+        var sourceApp = _captureSourceApp;
         var ext = CaptureOutputService.GetExtension(settings.CaptureImageFormat);
         if (!TryResolveCaptureOutputPath(
-                () => $"{Helpers.FileNameTemplate.Format(settings.FileNameTemplate, result.Width, result.Height)}.{ext}",
+                () => $"{FormatCaptureFileName(settings, result.Width, result.Height, sourceApp)}.{ext}",
                 settings.CaptureImageFormat,
                 "Capture error",
                 "OddSnap could not prepare the capture save path. Choose another save folder in Settings and try again.",
@@ -27,7 +28,7 @@ public partial class App
             return;
         }
 
-        _ = PersistCaptureAsync(result, requestedPath, saveHistory: settings.SaveHistory, isSticker: false, providerName: null)
+        _ = PersistCaptureAsync(result, requestedPath, saveHistory: settings.SaveHistory, isSticker: false, providerName: null, sourceApp: sourceApp)
             .ContinueWith(task =>
             {
                 if (task.IsFaulted)
@@ -102,8 +103,9 @@ public partial class App
     private void HandleStickerResult(Bitmap result, string providerName)
     {
         var settings = _settingsService!.Settings;
+        var sourceApp = _captureSourceApp;
         if (!TryResolveCaptureOutputPath(
-                () => $"{Helpers.FileNameTemplate.Format(settings.FileNameTemplate, result.Width, result.Height)}_sticker.png",
+                () => $"{FormatCaptureFileName(settings, result.Width, result.Height, sourceApp)}_sticker.png",
                 CaptureImageFormat.Png,
                 "Sticker error",
                 "OddSnap could not prepare the sticker save path. Choose another save folder in Settings and try again.",
@@ -113,7 +115,7 @@ public partial class App
             return;
         }
 
-        _ = PersistCaptureAsync(result, requestedPath, saveHistory: settings.SaveHistory, isSticker: true, providerName: providerName)
+        _ = PersistCaptureAsync(result, requestedPath, saveHistory: settings.SaveHistory, isSticker: true, providerName: providerName, sourceApp: sourceApp)
             .ContinueWith(task =>
             {
                 if (task.IsFaulted)
@@ -173,8 +175,9 @@ public partial class App
     private void HandleUpscaleResult(Bitmap result, string providerName)
     {
         var settings = _settingsService!.Settings;
+        var sourceApp = _captureSourceApp;
         if (!TryResolveCaptureOutputPath(
-                () => $"{Helpers.FileNameTemplate.Format(settings.FileNameTemplate, result.Width, result.Height)}_upscale.png",
+                () => $"{FormatCaptureFileName(settings, result.Width, result.Height, sourceApp)}_upscale.png",
                 CaptureImageFormat.Png,
                 "Upscale error",
                 "OddSnap could not prepare the upscale save path. Choose another save folder in Settings and try again.",
@@ -184,7 +187,7 @@ public partial class App
             return;
         }
 
-        _ = PersistCaptureAsync(result, requestedPath, saveHistory: settings.SaveHistory, isSticker: false, providerName: providerName)
+        _ = PersistCaptureAsync(result, requestedPath, saveHistory: settings.SaveHistory, isSticker: false, providerName: providerName, sourceApp: sourceApp)
             .ContinueWith(task =>
             {
                 if (task.IsFaulted)
@@ -299,12 +302,21 @@ public partial class App
         }
     }
 
+    private static string FormatCaptureFileName(AppSettings settings, int width, int height, string? sourceApp) =>
+        Helpers.FileNameTemplate.Format(
+            settings.FileNameTemplate,
+            width,
+            height,
+            sourceApp,
+            settings.IncludeSourceAppInFileName);
+
     private Task<PersistedCaptureResult> PersistCaptureAsync(
         Bitmap source,
         string? requestedPath,
         bool saveHistory,
         bool isSticker,
-        string? providerName)
+        string? providerName,
+        string? sourceApp = null)
     {
         var settings = _settingsService!.Settings;
         int maxLongEdge = settings.CaptureMaxLongEdge;
@@ -338,10 +350,12 @@ public partial class App
                         throw new InvalidOperationException("Save path must include a directory.");
 
                     Directory.CreateDirectory(directory);
-                    if (isSticker)
-                        CaptureOutputService.SaveBitmap(output, requestedPath, CaptureImageFormat.Png, jpegQuality);
-                    else
-                        CaptureOutputService.SaveBitmap(output, requestedPath, captureFormat, jpegQuality);
+                    var savedFormat = isSticker ? CaptureImageFormat.Png : captureFormat;
+                    CaptureOutputService.SaveBitmap(output, requestedPath, savedFormat, jpegQuality);
+                    Helpers.ImageMetadataWriter.TryWrite(
+                        requestedPath,
+                        savedFormat,
+                        Helpers.ImageMetadataWriter.BuildCaptureMetadata(sourceApp, DateTime.Now));
 
                     filePath = requestedPath;
                 }
@@ -355,13 +369,14 @@ public partial class App
                             output.Width,
                             output.Height,
                             isSticker ? HistoryKind.Sticker : HistoryKind.Image,
-                            providerName);
+                            providerName,
+                            sourceApp);
                     }
                     else
                     {
                         historyEntry = isSticker
                             ? historyService.SaveStickerEntry(output, providerName)
-                            : historyService.SaveCapture(output);
+                            : historyService.SaveCapture(output, sourceApp);
                         filePath = historyEntry.FilePath;
                     }
                 }

--- a/src/OddSnap/App/App.Capture.cs
+++ b/src/OddSnap/App/App.Capture.cs
@@ -38,6 +38,28 @@ public partial class App
         }, DispatcherPriority.Background, "capture.restore-settings-post");
     }
 
+    /// <summary>
+    /// App the current capture is attributed to. Seeded from the foreground window before any
+    /// OddSnap overlay takes focus, then narrowed to the window actually under the selection once
+    /// the user picks a region. Deliberately cleared when nothing can be attributed (our own
+    /// windows, the shell, the bare desktop) — a stale app name would be worse than no name.
+    /// </summary>
+    private string? _captureSourceApp;
+
+    private void CaptureSourceAppForCurrentCapture()
+    {
+        _captureSourceApp = Helpers.CaptureSourceApp.ResolveForeground();
+    }
+
+    /// <summary>
+    /// Re-attribute the capture to whatever window the selection was dragged over. The foreground
+    /// window is only a fallback: you can select a region of a background window without focusing it.
+    /// </summary>
+    private void AttributeCaptureToRegion(Rectangle region)
+    {
+        _captureSourceApp = Helpers.CaptureSourceApp.ResolveForRegion(region) ?? _captureSourceApp;
+    }
+
     private sealed class PersistedCaptureResult
     {
         public required Bitmap Output { get; init; }
@@ -305,6 +327,7 @@ public partial class App
         Bitmap? bmp = null;
         try
         {
+            CaptureSourceAppForCurrentCapture();
             (bmp, _) = ScreenCapture.CaptureAllScreens(_settingsService!.Settings.ShowCursor);
             HandleCaptureResult(bmp);
             bmp = null;
@@ -327,6 +350,7 @@ public partial class App
         {
             var bounds = ScreenCapture.GetVirtualScreenBounds();
             var hwnd = Native.User32.GetForegroundWindow();
+            _captureSourceApp = Helpers.CaptureSourceApp.ResolveForWindow(hwnd);
             if (!WindowDetector.TryGetCapturableWindowBounds(hwnd, bounds, out var windowRect, out var failureMessage))
             {
                 ResetCapturing();
@@ -393,12 +417,17 @@ public partial class App
         Bitmap? screenshot = null;
         try
         {
+            CaptureSourceAppForCurrentCapture();
             var screenshotStarted = PerformanceTrace.Timestamp();
             bool showCursor = _settingsService!.Settings.ShowCursor;
             var (bmp, bounds) = _settingsService.Settings.OverlayCaptureAllMonitors
                 ? ScreenCapture.CaptureAllScreensLowLatency(showCursor)
                 : ScreenCapture.CaptureCurrentScreenLowLatency(showCursor);
             screenshot = bmp;
+
+            // Record the window layout that matches these pixels, so a selection can be attributed
+            // to the window it was dragged over rather than to whatever happened to have focus.
+            Helpers.CaptureSourceApp.SnapshotWindows(bounds);
             PerformanceTrace.LogIfSlow(
                 "perf.capture.overlay-screenshot",
                 screenshotStarted,
@@ -433,6 +462,7 @@ public partial class App
             overlay.RegionSelected += sel =>
             {
                 overlay.Hide();
+                AttributeCaptureToRegion(sel);
                 using var annotated = overlay.RenderAnnotatedBitmap();
                 var cropped = ScreenCapture.CropRegion(annotated, sel);
                 overlay.Close();
@@ -449,6 +479,7 @@ public partial class App
             overlay.OcrRegionSelected += sel =>
             {
                 overlay.Hide();
+                AttributeCaptureToRegion(sel);
                 using var annotated = overlay.RenderAnnotatedBitmap();
                 var cropped = ScreenCapture.CropRegion(annotated, sel);
                 overlay.Close();
@@ -517,6 +548,7 @@ public partial class App
             overlay.StickerRegionSelected += sel =>
             {
                 overlay.Hide();
+                AttributeCaptureToRegion(sel);
                 using var annotated = overlay.RenderAnnotatedBitmap();
                 var sticker = ScreenCapture.CropRegion(annotated, sel);
                 overlay.Close();
@@ -560,6 +592,7 @@ public partial class App
             overlay.UpscaleRegionSelected += sel =>
             {
                 overlay.Hide();
+                AttributeCaptureToRegion(sel);
                 using var annotated = overlay.RenderAnnotatedBitmap();
                 var upscaled = ScreenCapture.CropRegion(annotated, sel);
                 overlay.Close();
@@ -647,6 +680,7 @@ public partial class App
 
             overlay.FormClosed += (_, _) =>
             {
+                Helpers.CaptureSourceApp.ClearSnapshot();
                 screenshot?.Dispose();
                 screenshot = null;
 

--- a/src/OddSnap/App/App.Startup.cs
+++ b/src/OddSnap/App/App.Startup.cs
@@ -77,6 +77,7 @@ public partial class App
         UiScale.Set(_settingsService.Settings.UiScale);
         Theme.Refresh();
         Theme.ApplyTo(Resources);
+        OddSnapWindowChrome.SetRoundedCornersEnabled(_settingsService.Settings.UseRoundedCorners);
         Helpers.UiChrome.DetectRefreshRate();
         ToastWindow.SetPosition(_settingsService.Settings.ToastPosition);
         ToastWindow.SetDuration(_settingsService.Settings.ToastDurationSeconds);

--- a/src/OddSnap/Capture/RegionOverlayForm.Input.Keyboard.cs
+++ b/src/OddSnap/Capture/RegionOverlayForm.Input.Keyboard.cs
@@ -85,20 +85,15 @@ public sealed partial class RegionOverlayForm
             return;
         }
 
-        // Delete selected annotation
-        if (e.KeyCode == Keys.Delete && _mode == CaptureMode.Select && _selectedAnnotationIndex >= 0 && _selectedAnnotationIndex < _undoStack.Count)
+        // Delete selected annotation. Backspace is accepted too — it's the key most people reach
+        // for, and nothing else in the overlay uses it outside text editing (handled above).
+        if (e.KeyCode is Keys.Delete or Keys.Back && _mode == CaptureMode.Select)
         {
-            var bounds = InflateForRepaint(GetAnnotationBounds(_undoStack[_selectedAnnotationIndex]));
-            CancelActivePointerInteraction();
-            _undoStack.RemoveAt(_selectedAnnotationIndex);
-            _redoStack.Clear();
-            MarkCommittedAnnotationsDirty();
-            _selectedAnnotationIndex = -1;
-            _selectPreviewAnnotation = null;
-            _renderSkipIndex = -1;
-            _isSelectDragging = false;
-            _isSelectResizing = false;
-            Invalidate(bounds);
+            if (DeleteSelectedAnnotation())
+            {
+                e.SuppressKeyPress = true;
+                e.Handled = true;
+            }
             return;
         }
     }

--- a/src/OddSnap/Capture/RegionOverlayForm.Input.Tools.cs
+++ b/src/OddSnap/Capture/RegionOverlayForm.Input.Tools.cs
@@ -186,7 +186,7 @@ public sealed partial class RegionOverlayForm
         {
             ClearCrosshairGuides();
             SetSnapGuides(false, false);
-            var oldBounds = GetAnnotationBounds(_selectPreviewAnnotation ?? _undoStack[_selectedAnnotationIndex]);
+            var oldBounds = GetSelectionChromeBounds(_selectPreviewAnnotation ?? _undoStack[_selectedAnnotationIndex]);
             int dx = e.Location.X - _selectDragStart.X;
             int dy = e.Location.Y - _selectDragStart.Y;
             var ob = _selectHandleBounds;
@@ -202,8 +202,7 @@ public sealed partial class RegionOverlayForm
             {
                 var scaled = ScaleAnnotation(_selectResizeOriginalAnnotation, ob, nb);
                 _selectPreviewAnnotation = scaled;
-                var newBounds = GetAnnotationBounds(scaled);
-                InvalidateLiveTransform(oldBounds, newBounds);
+                InvalidateLiveTransform(oldBounds, GetSelectionChromeBounds(scaled));
             }
             return;
         }
@@ -224,7 +223,9 @@ public sealed partial class RegionOverlayForm
             {
                 var moved = MoveAnnotation(current, dx, dy);
                 _selectPreviewAnnotation = moved;
-                InvalidateLiveTransform(currentBounds, GetAnnotationBounds(moved));
+                InvalidateLiveTransform(
+                    GetSelectionChromeBounds(current),
+                    GetSelectionChromeBounds(moved));
             }
             else
                 SetSnapGuides(false, false);
@@ -269,7 +270,11 @@ public sealed partial class RegionOverlayForm
         else if (_mode == CaptureMode.Select)
         {
             int sh = GetSelectHandle(e.Location);
-            if (sh >= 0) target = sh is 0 or 3 ? Cursors.SizeNWSE : Cursors.SizeNESW;
+            bool overDelete = IsPointInSelectDeleteButton(e.Location);
+            SetSelectDeleteHovered(overDelete);
+
+            if (overDelete) target = Cursors.Hand;
+            else if (sh >= 0) target = sh is 0 or 3 ? Cursors.SizeNWSE : Cursors.SizeNESW;
             else if (_selectedAnnotationIndex >= 0 && GetAnnotationBounds(_undoStack[_selectedAnnotationIndex]).Contains(e.Location))
                 target = Cursors.SizeAll;
             else

--- a/src/OddSnap/Capture/RegionOverlayForm.Input.cs
+++ b/src/OddSnap/Capture/RegionOverlayForm.Input.cs
@@ -200,6 +200,14 @@ public sealed partial class RegionOverlayForm
         // Select tool: check resize handles first, then hit-test annotations
         if (_mode == CaptureMode.Select)
         {
+            // The delete badge sits outside the frame, so it has to win over the handles below it.
+            if (IsPointInSelectDeleteButton(e.Location))
+            {
+                _hoveredSelectDelete = false;
+                DeleteSelectedAnnotation();
+                return;
+            }
+
             // Check resize handles on already-selected annotation
             int handle = GetSelectHandle(e.Location);
             if (handle >= 0 && _selectedAnnotationIndex >= 0)

--- a/src/OddSnap/Capture/RegionOverlayForm.Paint.cs
+++ b/src/OddSnap/Capture/RegionOverlayForm.Paint.cs
@@ -84,6 +84,8 @@ public sealed partial class RegionOverlayForm
                 };
                 foreach (var c in corners)
                     WindowsHandleRenderer.Paint(g, WindowsHandleRenderer.CenteredAt(c));
+
+                PaintSelectDeleteButton(g);
             }
         }
 
@@ -498,4 +500,40 @@ public sealed partial class RegionOverlayForm
         }
     }
 
+    /// <summary>
+    /// Draws the delete badge on the selected annotation. Keyboard Delete already worked, but there
+    /// was nothing on screen telling you an annotation could be removed at all.
+    /// </summary>
+    private void PaintSelectDeleteButton(Graphics g)
+    {
+        var rect = GetSelectDeleteButtonRect();
+        if (rect.IsEmpty)
+            return;
+
+        bool hovered = _hoveredSelectDelete;
+        var fill = hovered
+            ? Color.FromArgb(255, 232, 68, 58)
+            : Color.FromArgb(235, 200, 48, 40);
+
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+
+        using (var shadow = new SolidBrush(Color.FromArgb(70, 0, 0, 0)))
+            g.FillEllipse(shadow, rect.X + 1, rect.Y + 1, rect.Width, rect.Height);
+
+        using (var brush = new SolidBrush(fill))
+            g.FillEllipse(brush, rect);
+
+        using (var border = new Pen(Color.FromArgb(190, 255, 255, 255), 1f))
+            g.DrawEllipse(border, rect);
+
+        // The glyph is a plain X so it reads at any UI scale.
+        float inset = rect.Width * 0.32f;
+        using var cross = new Pen(Color.White, Math.Max(1.6f, rect.Width * 0.11f))
+        {
+            StartCap = System.Drawing.Drawing2D.LineCap.Round,
+            EndCap = System.Drawing.Drawing2D.LineCap.Round
+        };
+        g.DrawLine(cross, rect.Left + inset, rect.Top + inset, rect.Right - inset, rect.Bottom - inset);
+        g.DrawLine(cross, rect.Right - inset, rect.Top + inset, rect.Left + inset, rect.Bottom - inset);
+    }
 }

--- a/src/OddSnap/Capture/RegionOverlayForm.State.cs
+++ b/src/OddSnap/Capture/RegionOverlayForm.State.cs
@@ -500,6 +500,104 @@ public sealed partial class RegionOverlayForm
     private static Point Offset(Point p, int dx, int dy) => new(p.X + dx, p.Y + dy);
     private static Rectangle OffsetRect(Rectangle r, int dx, int dy) => new(r.X + dx, r.Y + dy, r.Width, r.Height);
 
+    /// <summary>Diameter of the delete badge shown on a selected annotation.</summary>
+    private const int SelectDeleteButtonSize = 22;
+
+    /// <summary>Gap between the selection frame and the delete badge.</summary>
+    private const int SelectDeleteButtonGap = 6;
+
+    private bool HasSelectedAnnotation =>
+        _selectedAnnotationIndex >= 0 && _selectedAnnotationIndex < _undoStack.Count;
+
+    /// <summary>
+    /// On-screen delete affordance for the selected annotation. Sits just outside the top-right of
+    /// the selection frame, folding inside when the annotation is against a screen edge. Empty when
+    /// nothing is selected.
+    /// </summary>
+    private Rectangle GetSelectDeleteButtonRect()
+    {
+        if (!HasSelectedAnnotation)
+            return Rectangle.Empty;
+
+        return GetSelectDeleteButtonRectFor(_selectPreviewAnnotation ?? _undoStack[_selectedAnnotationIndex]);
+    }
+
+    /// <summary>
+    /// Selection frame plus its delete badge. Repaint regions must use this, not the raw annotation
+    /// bounds — the badge hangs outside the frame and would otherwise smear while dragging.
+    /// </summary>
+    private Rectangle GetSelectionChromeBounds(Annotation a)
+    {
+        var bounds = GetAnnotationBounds(a);
+        var badge = GetSelectDeleteButtonRectFor(a);
+        return badge.IsEmpty ? bounds : Rectangle.Union(bounds, badge);
+    }
+
+    private Rectangle GetSelectDeleteButtonRectFor(Annotation a)
+    {
+        var bounds = GetAnnotationBounds(a);
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+            return Rectangle.Empty;
+
+        var selRect = Rectangle.Inflate(bounds, 4, 4);
+        int size = Helpers.UiChrome.ScaleInt(SelectDeleteButtonSize);
+        int gap = Helpers.UiChrome.ScaleInt(SelectDeleteButtonGap);
+
+        int x = selRect.Right + gap;
+        int y = selRect.Y - size - gap;
+
+        if (x + size > ClientSize.Width - 2)
+            x = Math.Max(2, selRect.Right - size);
+        if (y < 2)
+            y = Math.Min(ClientSize.Height - size - 2, selRect.Y + gap);
+
+        if (x < 2 || y < 2)
+            return Rectangle.Empty;
+
+        return new Rectangle(x, y, size, size);
+    }
+
+    private bool IsPointInSelectDeleteButton(Point p)
+    {
+        var rect = GetSelectDeleteButtonRect();
+        return !rect.IsEmpty && rect.Contains(p);
+    }
+
+    private void SetSelectDeleteHovered(bool hovered)
+    {
+        if (_hoveredSelectDelete == hovered)
+            return;
+
+        _hoveredSelectDelete = hovered;
+        var badge = GetSelectDeleteButtonRect();
+        if (!badge.IsEmpty)
+            Invalidate(InflateForRepaint(badge));
+    }
+
+    /// <summary>Removes the selected annotation. Shared by the delete badge and the Delete key.</summary>
+    private bool DeleteSelectedAnnotation()
+    {
+        if (!HasSelectedAnnotation)
+            return false;
+
+        var bounds = InflateForRepaint(GetAnnotationBounds(_undoStack[_selectedAnnotationIndex]));
+        var badge = GetSelectDeleteButtonRect();
+        CancelActivePointerInteraction();
+        _undoStack.RemoveAt(_selectedAnnotationIndex);
+        _redoStack.Clear();
+        MarkCommittedAnnotationsDirty();
+        _selectedAnnotationIndex = -1;
+        _selectPreviewAnnotation = null;
+        _renderSkipIndex = -1;
+        _isSelectDragging = false;
+        _isSelectResizing = false;
+
+        if (!badge.IsEmpty)
+            bounds = Rectangle.Union(bounds, InflateForRepaint(badge));
+        Invalidate(bounds);
+        return true;
+    }
+
     /// <summary>Returns the handle index (0=TL,1=TR,2=BL,3=BR) at point, or -1.</summary>
     private int GetSelectHandle(Point p)
     {

--- a/src/OddSnap/Capture/RegionOverlayForm.cs
+++ b/src/OddSnap/Capture/RegionOverlayForm.cs
@@ -169,6 +169,7 @@ public sealed partial class RegionOverlayForm : Form
 
     // Select tool state
     private int _selectedAnnotationIndex = -1;
+    private bool _hoveredSelectDelete;
     private bool _isSelectDragging;
     private bool _isSelectResizing;
     private int _selectResizeHandle = -1; // 0=TL,1=TR,2=BL,3=BR

--- a/src/OddSnap/Helpers/CaptureSourceApp.cs
+++ b/src/OddSnap/Helpers/CaptureSourceApp.cs
@@ -1,0 +1,282 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using OddSnap.Native;
+using OddSnap.Services;
+
+namespace OddSnap.Helpers;
+
+/// <summary>
+/// Resolves the app a capture was taken from ("Discord", "Task Manager", ...) so it can be
+/// written into the file name, the saved image metadata, and the history database.
+///
+/// For region captures the foreground window is the wrong answer — you can drag a selection over a
+/// background window without ever focusing it. So the overlay flow snapshots the desktop's window
+/// z-order before it opens, then attributes the capture to whatever window actually sits under the
+/// selected pixels.
+/// </summary>
+public static class CaptureSourceApp
+{
+    private const int MaxNameLength = 40;
+
+    private readonly record struct SnapshotWindow(Rectangle Rect, uint ProcessId);
+
+    private sealed record WindowSnapshot(Rectangle VirtualBounds, SnapshotWindow[] Windows);
+
+    private static readonly object SnapshotLock = new();
+    private static WindowSnapshot? _snapshot;
+
+    /// <summary>Window classes that belong to the shell, not to a real source app.</summary>
+    private static readonly string[] ShellWindowClasses =
+    {
+        "Progman",
+        "WorkerW",
+        "Shell_TrayWnd",
+        "Shell_SecondaryTrayWnd",
+        "NotifyIconOverflowWindow",
+        "Windows.UI.Core.CoreWindow",
+        "tooltips_class32",
+        "#32768"
+    };
+
+    // ── Foreground attribution (fullscreen / active-window capture) ──
+
+    /// <summary>Foreground app right now, or null when it can't be attributed.</summary>
+    public static string? ResolveForeground()
+        => ResolveForWindow(User32.GetForegroundWindow());
+
+    public static string? ResolveForWindow(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero)
+            return null;
+
+        try
+        {
+            if (IsShellWindow(hwnd))
+                return null;
+
+            _ = User32.GetWindowThreadProcessId(hwnd, out var processId);
+            return ResolveForProcess(processId);
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning("capture.source-app", $"Failed to resolve capture source app: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    // ── Region attribution (overlay capture) ──
+
+    /// <summary>
+    /// Records the visible top-level windows in z-order. Call this from the overlay capture flow
+    /// before the overlay is shown, while the desktop still looks the way the screenshot does.
+    /// </summary>
+    public static void SnapshotWindows(Rectangle virtualBounds)
+    {
+        try
+        {
+            var windows = new List<SnapshotWindow>();
+            var seen = new HashSet<IntPtr>();
+
+            User32.EnumWindows((hwnd, _) =>
+            {
+                if (hwnd == IntPtr.Zero || !seen.Add(hwnd))
+                    return true;
+
+                if (!TryGetAttributableWindow(hwnd, virtualBounds, out var window))
+                    return true;
+
+                windows.Add(window);
+                return true;
+            }, IntPtr.Zero);
+
+            lock (SnapshotLock)
+                _snapshot = new WindowSnapshot(virtualBounds, windows.ToArray());
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning("capture.source-app.snapshot", ex.Message, ex);
+            ClearSnapshot();
+        }
+    }
+
+    public static void ClearSnapshot()
+    {
+        lock (SnapshotLock)
+            _snapshot = null;
+    }
+
+    /// <summary>
+    /// App behind <paramref name="region"/> (overlay coordinates, i.e. relative to the captured
+    /// virtual-screen bounds). Returns null when the region is over the desktop or the snapshot
+    /// is missing.
+    /// </summary>
+    public static string? ResolveForRegion(Rectangle region)
+    {
+        WindowSnapshot? snapshot;
+        lock (SnapshotLock)
+            snapshot = _snapshot;
+
+        if (snapshot is null || region.Width <= 0 || region.Height <= 0)
+            return null;
+
+        var processId = FindProcessIdForRegion(snapshot, region);
+        return processId == 0 ? null : ResolveForProcess(processId);
+    }
+
+    private static uint FindProcessIdForRegion(WindowSnapshot snapshot, Rectangle region)
+    {
+        // The windows are in z-order, so the first hit is the one actually drawn there.
+        var center = new Point(region.X + region.Width / 2, region.Y + region.Height / 2);
+        foreach (var window in snapshot.Windows)
+        {
+            if (window.Rect.Contains(center))
+                return window.ProcessId;
+        }
+
+        // Selection center landed on the desktop (or on a gap): fall back to whichever window
+        // covers most of the selection.
+        uint bestProcessId = 0;
+        long bestArea = 0;
+        foreach (var window in snapshot.Windows)
+        {
+            var overlap = Rectangle.Intersect(window.Rect, region);
+            long area = (long)overlap.Width * overlap.Height;
+            if (area > bestArea)
+            {
+                bestArea = area;
+                bestProcessId = window.ProcessId;
+            }
+        }
+
+        // Ignore incidental slivers — a few stray pixels shouldn't rename the file.
+        long regionArea = (long)region.Width * region.Height;
+        return bestArea * 4 >= regionArea ? bestProcessId : 0u;
+    }
+
+    private static bool TryGetAttributableWindow(IntPtr hwnd, Rectangle virtualBounds, out SnapshotWindow window)
+    {
+        window = default;
+
+        if (!User32.IsWindowVisible(hwnd) || User32.IsIconic(hwnd) || Dwm.IsWindowCloaked(hwnd))
+            return false;
+
+        if (IsShellWindow(hwnd))
+            return false;
+
+        int style = User32.GetWindowLongA(hwnd, User32.GWL_STYLE);
+        int exStyle = User32.GetWindowLongA(hwnd, User32.GWL_EXSTYLE);
+        if ((style & User32.WS_CHILD) != 0)
+            return false;
+        if ((exStyle & User32.WS_EX_TRANSPARENT) != 0)
+            return false;
+        if ((exStyle & User32.WS_EX_TOOLWINDOW) != 0 && (exStyle & User32.WS_EX_APPWINDOW) == 0)
+            return false;
+
+        _ = User32.GetWindowThreadProcessId(hwnd, out var processId);
+        if (processId == 0 || processId == Environment.ProcessId)
+            return false;
+
+        var bounds = Dwm.GetExtendedFrameBounds(hwnd);
+        if (bounds.Width <= 2 || bounds.Height <= 2)
+        {
+            if (!User32.GetWindowRect(hwnd, out var raw))
+                return false;
+
+            bounds = raw.ToRectangle();
+            if (bounds.Width <= 2 || bounds.Height <= 2)
+                return false;
+        }
+
+        window = new SnapshotWindow(
+            new Rectangle(
+                bounds.Left - virtualBounds.X,
+                bounds.Top - virtualBounds.Y,
+                bounds.Width,
+                bounds.Height),
+            processId);
+        return true;
+    }
+
+    // ── Shared ──
+
+    private static string? ResolveForProcess(uint processId)
+    {
+        if (processId == 0 || processId == Environment.ProcessId)
+            return null;
+
+        try
+        {
+            using var process = Process.GetProcessById((int)processId);
+            return Normalize(GetFriendlyProcessName(process));
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning("capture.source-app.process", ex.Message, ex);
+            return null;
+        }
+    }
+
+    /// <summary>Make an app name safe to embed in a file name (letters, digits, dashes).</summary>
+    public static string? SanitizeForFileName(string? appName)
+    {
+        if (string.IsNullOrWhiteSpace(appName))
+            return null;
+
+        var buffer = new System.Text.StringBuilder(appName.Length);
+        foreach (var c in appName)
+        {
+            if (char.IsLetterOrDigit(c))
+                buffer.Append(c);
+            else if (c is ' ' or '-' or '_' or '.' && buffer.Length > 0 && buffer[^1] != '-')
+                buffer.Append('-');
+        }
+
+        var result = buffer.ToString().Trim('-');
+        return result.Length == 0 ? null : result;
+    }
+
+    private static string? GetFriendlyProcessName(Process process)
+    {
+        try
+        {
+            var description = process.MainModule?.FileVersionInfo.FileDescription;
+            if (!string.IsNullOrWhiteSpace(description))
+                return description;
+
+            var fileName = process.MainModule?.FileName;
+            if (!string.IsNullOrWhiteSpace(fileName))
+                return Path.GetFileNameWithoutExtension(fileName);
+        }
+        catch (Exception ex)
+        {
+            // Elevated or protected processes deny module access; the process name still works.
+            AppDiagnostics.LogWarning("capture.source-app.module", ex.Message, ex);
+        }
+
+        return process.ProcessName;
+    }
+
+    private static string? Normalize(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        var trimmed = name.Trim();
+        if (trimmed.Length > MaxNameLength)
+            trimmed = trimmed[..MaxNameLength].TrimEnd();
+
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static bool IsShellWindow(IntPtr hwnd)
+    {
+        var buffer = new char[256];
+        int copied = User32.GetClassNameW(hwnd, buffer, buffer.Length);
+        if (copied <= 0)
+            return false;
+
+        var className = new string(buffer, 0, copied);
+        return ShellWindowClasses.Any(shell => string.Equals(shell, className, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/OddSnap/Helpers/FileNameTemplate.cs
+++ b/src/OddSnap/Helpers/FileNameTemplate.cs
@@ -5,25 +5,56 @@ public static class FileNameTemplate
     public const string DefaultTemplate = "{year}-{month}-{day}-{hour}-{min}-{sec}-{rand}";
     public const string LegacyDefaultTemplate = "oddsnap_{year}-{month}-{day}_{hour}-{min}-{sec}_{rand}";
 
+    public const string SourceAppToken = "{app}";
+
     public static string Format(string template, int width = 0, int height = 0)
     {
         var now = DateTime.Now;
         var randomToken = Guid.NewGuid().ToString("N").Substring(0, 4);
-        return Render(template, now, randomToken, width, height);
+        return Render(template, now, randomToken, width, height, sourceApp: null, appendSourceApp: false);
+    }
+
+    /// <summary>
+    /// Format a template for a capture taken from <paramref name="sourceApp"/>. When the template has no
+    /// <c>{app}</c> token and <paramref name="appendSourceApp"/> is set, the app name is appended instead,
+    /// so saved files stay searchable by the app they came from.
+    /// </summary>
+    public static string Format(string template, int width, int height, string? sourceApp, bool appendSourceApp)
+    {
+        var now = DateTime.Now;
+        var randomToken = Guid.NewGuid().ToString("N").Substring(0, 4);
+        return Render(template, now, randomToken, width, height, sourceApp, appendSourceApp);
     }
 
     /// <summary>Format a preset with a fixed example date (2026-04-05 14:30:52) for display.</summary>
     public static string FormatExample(string template)
-        => Render(template, new DateTime(2026, 4, 5, 14, 30, 52), "a3f1", 1920, 1080);
+        => Render(template, new DateTime(2026, 4, 5, 14, 30, 52), "a3f1", 1920, 1080, sourceApp: null, appendSourceApp: false);
 
-    private static string Render(string template, DateTime now, string randomToken, int width, int height)
+    /// <summary>Preview a template as it will look for a capture taken from <paramref name="sourceApp"/>.</summary>
+    public static string FormatExample(string template, string? sourceApp, bool appendSourceApp)
+        => Render(template, new DateTime(2026, 4, 5, 14, 30, 52), "a3f1", 1920, 1080, sourceApp, appendSourceApp);
+
+    private static string Render(
+        string template,
+        DateTime now,
+        string randomToken,
+        int width,
+        int height,
+        string? sourceApp,
+        bool appendSourceApp)
     {
         bool blankTemplate = string.IsNullOrWhiteSpace(template);
         template = NormalizeLegacyPlaceholders(template);
         if (blankTemplate)
             template = DefaultTemplate;
 
+        var appToken = CaptureSourceApp.SanitizeForFileName(sourceApp);
+        bool templateHasAppToken = template.Contains(SourceAppToken, StringComparison.OrdinalIgnoreCase);
+        if (appendSourceApp && !templateHasAppToken && appToken is not null)
+            template += $"_{SourceAppToken}";
+
         var result = template
+            .Replace(SourceAppToken, appToken ?? "", StringComparison.OrdinalIgnoreCase)
             .Replace("{datetime}", now.ToString("yyyyMMdd_HHmmss"))
             .Replace("{date}", now.ToString("yyyyMMdd"))
             .Replace("{time}", now.ToString("HHmmss"))

--- a/src/OddSnap/Helpers/ImageMetadataWriter.cs
+++ b/src/OddSnap/Helpers/ImageMetadataWriter.cs
@@ -1,0 +1,208 @@
+using System.IO;
+using System.Text;
+using OddSnap.Models;
+using OddSnap.Services;
+
+namespace OddSnap.Helpers;
+
+/// <summary>
+/// Writes capture provenance ("Source app: Discord", capture time, OddSnap version) into the saved
+/// image itself: PNG <c>tEXt</c> chunks, JPEG <c>COM</c> comment segments. Failures are non-fatal —
+/// the capture is already on disk by the time this runs.
+/// </summary>
+public static class ImageMetadataWriter
+{
+    public const string SoftwareKey = "Software";
+    public const string SourceAppKey = "Source";
+    public const string CreationTimeKey = "Creation Time";
+
+    /// <summary>Builds the standard capture metadata pairs; returns an empty list when nothing is known.</summary>
+    public static List<KeyValuePair<string, string>> BuildCaptureMetadata(string? sourceApp, DateTime capturedAt)
+    {
+        var metadata = new List<KeyValuePair<string, string>>
+        {
+            new(SoftwareKey, $"OddSnap {UpdateService.GetCurrentVersionLabel()}"),
+            new(CreationTimeKey, capturedAt.ToString("yyyy-MM-ddTHH:mm:ssK"))
+        };
+
+        if (!string.IsNullOrWhiteSpace(sourceApp))
+            metadata.Add(new KeyValuePair<string, string>(SourceAppKey, sourceApp));
+
+        return metadata;
+    }
+
+    public static void TryWrite(
+        string filePath,
+        CaptureImageFormat format,
+        IReadOnlyList<KeyValuePair<string, string>> metadata)
+    {
+        if (metadata.Count == 0 || string.IsNullOrWhiteSpace(filePath))
+            return;
+
+        try
+        {
+            switch (format)
+            {
+                case CaptureImageFormat.Png:
+                    WritePngTextChunks(filePath, metadata);
+                    break;
+                case CaptureImageFormat.Jpeg:
+                    WriteJpegComment(filePath, FormatComment(metadata));
+                    break;
+                // BMP has no standard place for this; the file name and history keep the attribution.
+            }
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning(
+                "capture.metadata",
+                $"Failed to write metadata into {Path.GetFileName(filePath)}: {ex.Message}",
+                ex);
+        }
+    }
+
+    private static string FormatComment(IReadOnlyList<KeyValuePair<string, string>> metadata)
+        => string.Join("; ", metadata.Select(pair => $"{pair.Key}: {pair.Value}"));
+
+    /// <summary>Inserts PNG tEXt chunks immediately before IEND.</summary>
+    private static void WritePngTextChunks(string filePath, IReadOnlyList<KeyValuePair<string, string>> metadata)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        int iendOffset = FindPngIendChunkOffset(bytes);
+        if (iendOffset < 0)
+            return;
+
+        using var output = new MemoryStream(bytes.Length + 256);
+        output.Write(bytes, 0, iendOffset);
+        foreach (var pair in metadata)
+            WritePngTextChunk(output, pair.Key, pair.Value);
+        output.Write(bytes, iendOffset, bytes.Length - iendOffset);
+
+        WriteAllBytesAtomic(filePath, output.ToArray());
+    }
+
+    private static int FindPngIendChunkOffset(byte[] bytes)
+    {
+        // 8-byte signature, then length(4) + type(4) + data + crc(4) chunks.
+        if (bytes.Length < 12 || bytes[0] != 0x89 || bytes[1] != 'P' || bytes[2] != 'N' || bytes[3] != 'G')
+            return -1;
+
+        int offset = 8;
+        while (offset + 8 <= bytes.Length)
+        {
+            uint length = ReadBigEndianUInt32(bytes, offset);
+            if (length > int.MaxValue - 12)
+                return -1;
+
+            var type = Encoding.ASCII.GetString(bytes, offset + 4, 4);
+            if (type == "IEND")
+                return offset;
+
+            offset += 12 + (int)length;
+        }
+
+        return -1;
+    }
+
+    private static void WritePngTextChunk(Stream output, string keyword, string text)
+    {
+        // tEXt keywords are Latin-1, 1-79 characters, followed by a null separator and the value.
+        var keywordBytes = Encoding.Latin1.GetBytes(keyword);
+        if (keywordBytes.Length is 0 or > 79)
+            return;
+
+        var textBytes = Encoding.Latin1.GetBytes(text);
+        var payload = new byte[4 + keywordBytes.Length + 1 + textBytes.Length];
+        Encoding.ASCII.GetBytes("tEXt").CopyTo(payload, 0);
+        keywordBytes.CopyTo(payload, 4);
+        payload[4 + keywordBytes.Length] = 0;
+        textBytes.CopyTo(payload, 4 + keywordBytes.Length + 1);
+
+        WriteBigEndianUInt32(output, (uint)(payload.Length - 4));
+        output.Write(payload, 0, payload.Length);
+        WriteBigEndianUInt32(output, ComputeCrc32(payload));
+    }
+
+    private static readonly uint[] Crc32Table = BuildCrc32Table();
+
+    private static uint[] BuildCrc32Table()
+    {
+        var table = new uint[256];
+        for (uint i = 0; i < 256; i++)
+        {
+            uint value = i;
+            for (int bit = 0; bit < 8; bit++)
+                value = (value & 1) != 0 ? 0xEDB88320u ^ (value >> 1) : value >> 1;
+            table[i] = value;
+        }
+
+        return table;
+    }
+
+    private static uint ComputeCrc32(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFFu;
+        foreach (var b in data)
+            crc = Crc32Table[(crc ^ b) & 0xFF] ^ (crc >> 8);
+
+        return crc ^ 0xFFFFFFFFu;
+    }
+
+    /// <summary>Inserts a JPEG COM segment right after the SOI marker.</summary>
+    private static void WriteJpegComment(string filePath, string comment)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        if (bytes.Length < 2 || bytes[0] != 0xFF || bytes[1] != 0xD8)
+            return;
+
+        var commentBytes = Encoding.UTF8.GetBytes(comment);
+        if (commentBytes.Length > 65_533)
+            commentBytes = commentBytes[..65_533];
+
+        int segmentLength = commentBytes.Length + 2;
+        using var output = new MemoryStream(bytes.Length + segmentLength + 2);
+        output.Write(bytes, 0, 2);
+        output.WriteByte(0xFF);
+        output.WriteByte(0xFE);
+        output.WriteByte((byte)(segmentLength >> 8));
+        output.WriteByte((byte)(segmentLength & 0xFF));
+        output.Write(commentBytes, 0, commentBytes.Length);
+        output.Write(bytes, 2, bytes.Length - 2);
+
+        WriteAllBytesAtomic(filePath, output.ToArray());
+    }
+
+    private static void WriteAllBytesAtomic(string filePath, byte[] contents)
+    {
+        var tempPath = filePath + ".meta.tmp";
+        try
+        {
+            File.WriteAllBytes(tempPath, contents);
+            File.Move(tempPath, filePath, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch
+            {
+                // Nothing else to do; the original capture file is untouched.
+            }
+            throw;
+        }
+    }
+
+    private static uint ReadBigEndianUInt32(byte[] bytes, int offset)
+        => (uint)((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]);
+
+    private static void WriteBigEndianUInt32(Stream output, uint value)
+    {
+        output.WriteByte((byte)(value >> 24));
+        output.WriteByte((byte)(value >> 16));
+        output.WriteByte((byte)(value >> 8));
+        output.WriteByte((byte)value);
+    }
+}

--- a/src/OddSnap/Models/AppSettings.cs
+++ b/src/OddSnap/Models/AppSettings.cs
@@ -9,6 +9,20 @@ public enum AfterCaptureAction
     PreviewOnly
 }
 
+/// <summary>What a left click on the tray icon does.</summary>
+public enum TrayClickAction
+{
+    Capture,
+    FullScreen,
+    TextCapture,
+    ColorPicker,
+    Record,
+    ScrollCapture,
+    History,
+    Settings,
+    Nothing
+}
+
 public enum ToastPosition
 {
     Right,
@@ -175,6 +189,8 @@ public sealed class AppSettings
     public bool SaveToFile { get; set; } = true;
     public bool AskForFileNameOnSave { get; set; }
     public string FileNameTemplate { get; set; } = Helpers.FileNameTemplate.DefaultTemplate;
+    /// <summary>Append the source app name to saved captures when the template has no {app} token.</summary>
+    public bool IncludeSourceAppInFileName { get; set; } = true;
     public CaptureImageFormat CaptureImageFormat { get; set; } = CaptureImageFormat.Png;
     public bool StyleScreenshots { get; set; }
     public bool AddScreenshotShadow { get; set; }
@@ -193,6 +209,8 @@ public sealed class AppSettings
     public bool SaveHistory { get; set; } = true;
     public bool MuteSounds { get; set; }
     public bool DisableAnimations { get; set; }
+    /// <summary>Rounded window/card corners. Off gives OddSnap square, flat chrome.</summary>
+    public bool UseRoundedCorners { get; set; } = true;
     public double UiScale { get; set; } = 1.0;
     public string InterfaceLanguage { get; set; } = "auto";
     public bool ShowCrosshairGuides { get; set; } // off by default
@@ -205,6 +223,7 @@ public sealed class AppSettings
     public int JpegQuality { get; set; } = 85;
     public bool HasCompletedSetup { get; set; }
     public ToastPosition ToastPosition { get; set; } = ToastPosition.Right;
+    public TrayClickAction TrayLeftClickAction { get; set; } = TrayClickAction.Capture;
     public CaptureMode DefaultCaptureMode { get; set; } = CaptureMode.Rectangle;
     public CenterSelectionAspectRatio CenterSelectionAspectRatio { get; set; } = CenterSelectionAspectRatio.Free;
     public bool ShowToolNumberBadges { get; set; } = true;
@@ -404,8 +423,14 @@ public sealed record ToolDef(string Id, string Label, char Icon, CaptureMode? Mo
     public static List<string> DefaultToolbarOrderIds() =>
         AllToolbarItems().Select(t => t.Id).ToList();
 
+    /// <summary>
+    /// Capture tools plus Select. Select is the gateway to moving, resizing and deleting
+    /// annotations, so leaving it in the annotation flyout made editing look impossible.
+    /// </summary>
     public static List<string> DefaultPinnedToolbarIds() =>
-        AllTools.Where(t => t.Group == 0).Select(t => t.Id).ToList();
+        AllTools.Where(t => t.Group == 0).Select(t => t.Id)
+            .Append("select")
+            .ToList();
 
     public static bool IsCaptureTool(CaptureMode mode) =>
         AllTools.Any(t => t.Mode == mode && t.Group == 0);

--- a/src/OddSnap/Native/User32.cs
+++ b/src/OddSnap/Native/User32.cs
@@ -116,6 +116,7 @@ internal static partial class User32
     [LibraryImport("user32.dll")]
     public static partial int SetWindowLongA(IntPtr hWnd, int nIndex, int dwNewLong);
 
+
     [LibraryImport("user32.dll")]
     public static partial IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
 

--- a/src/OddSnap/Services/History/HistoryEntryUtilities.cs
+++ b/src/OddSnap/Services/History/HistoryEntryUtilities.cs
@@ -31,7 +31,8 @@ internal static class HistoryEntryUtilities
             Kind = entry.Kind,
             UploadUrl = entry.UploadUrl,
             UploadProvider = entry.UploadProvider,
-            UploadError = entry.UploadError
+            UploadError = entry.UploadError,
+            SourceApp = entry.SourceApp
         };
     }
 

--- a/src/OddSnap/Services/History/HistoryStore.cs
+++ b/src/OddSnap/Services/History/HistoryStore.cs
@@ -47,7 +47,8 @@ internal static class HistoryStore
                 kind INTEGER NOT NULL,
                 upload_url TEXT NULL,
                 upload_provider TEXT NULL,
-                upload_error TEXT NULL
+                upload_error TEXT NULL,
+                source_app TEXT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_history_entries_kind_captured_at
                 ON history_entries(kind, captured_at_ticks DESC);
@@ -81,6 +82,7 @@ internal static class HistoryStore
             """;
         command.ExecuteNonQuery();
         EnsureColumn(connection, "history_entries", "upload_error", "TEXT NULL");
+        EnsureColumn(connection, "history_entries", "source_app", "TEXT NULL");
     }
 
     public static HistoryLoadResult Load(string databasePath)
@@ -97,7 +99,7 @@ internal static class HistoryStore
         using (var entriesCommand = connection.CreateCommand())
         {
             entriesCommand.CommandText = """
-                SELECT file_name, file_path, captured_at_ticks, width, height, file_size_bytes, kind, upload_url, upload_provider, upload_error
+                SELECT file_name, file_path, captured_at_ticks, width, height, file_size_bytes, kind, upload_url, upload_provider, upload_error, source_app
                 FROM history_entries
                 ORDER BY captured_at_ticks DESC;
                 """;
@@ -115,7 +117,8 @@ internal static class HistoryStore
                     Kind = (HistoryKind)reader.GetInt32(6),
                     UploadUrl = reader.IsDBNull(7) ? null : reader.GetString(7),
                     UploadProvider = reader.IsDBNull(8) ? null : reader.GetString(8),
-                    UploadError = reader.IsDBNull(9) ? null : reader.GetString(9)
+                    UploadError = reader.IsDBNull(9) ? null : reader.GetString(9),
+                    SourceApp = reader.IsDBNull(10) ? null : reader.GetString(10)
                 };
 
                 if (!File.Exists(entry.FilePath))
@@ -334,8 +337,8 @@ internal static class HistoryStore
         var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = """
-            INSERT INTO history_entries(file_path, file_name, captured_at_ticks, width, height, file_size_bytes, kind, upload_url, upload_provider, upload_error)
-            VALUES($filePath, $fileName, $capturedAtTicks, $width, $height, $fileSizeBytes, $kind, $uploadUrl, $uploadProvider, $uploadError)
+            INSERT INTO history_entries(file_path, file_name, captured_at_ticks, width, height, file_size_bytes, kind, upload_url, upload_provider, upload_error, source_app)
+            VALUES($filePath, $fileName, $capturedAtTicks, $width, $height, $fileSizeBytes, $kind, $uploadUrl, $uploadProvider, $uploadError, $sourceApp)
             ON CONFLICT(file_path) DO UPDATE SET
                 file_name = excluded.file_name,
                 captured_at_ticks = excluded.captured_at_ticks,
@@ -345,7 +348,8 @@ internal static class HistoryStore
                 kind = excluded.kind,
                 upload_url = excluded.upload_url,
                 upload_provider = excluded.upload_provider,
-                upload_error = excluded.upload_error;
+                upload_error = excluded.upload_error,
+                source_app = excluded.source_app;
             """;
         command.Parameters.Add("$filePath", SqliteType.Text);
         command.Parameters.Add("$fileName", SqliteType.Text);
@@ -357,6 +361,7 @@ internal static class HistoryStore
         command.Parameters.Add("$uploadUrl", SqliteType.Text);
         command.Parameters.Add("$uploadProvider", SqliteType.Text);
         command.Parameters.Add("$uploadError", SqliteType.Text);
+        command.Parameters.Add("$sourceApp", SqliteType.Text);
         return command;
     }
 
@@ -372,6 +377,7 @@ internal static class HistoryStore
         command.Parameters["$uploadUrl"].Value = (object?)entry.UploadUrl ?? DBNull.Value;
         command.Parameters["$uploadProvider"].Value = (object?)entry.UploadProvider ?? DBNull.Value;
         command.Parameters["$uploadError"].Value = (object?)entry.UploadError ?? DBNull.Value;
+        command.Parameters["$sourceApp"].Value = (object?)entry.SourceApp ?? DBNull.Value;
         command.ExecuteNonQuery();
     }
 

--- a/src/OddSnap/Services/HistoryService.cs
+++ b/src/OddSnap/Services/HistoryService.cs
@@ -26,6 +26,8 @@ public sealed class HistoryEntry
     public string? UploadUrl { get; set; }
     public string? UploadProvider { get; set; }
     public string? UploadError { get; set; }
+    /// <summary>App the capture was taken from ("Discord", "Task Manager"), when it could be attributed.</summary>
+    public string? SourceApp { get; set; }
 }
 
 public sealed class OcrHistoryEntry
@@ -303,7 +305,7 @@ public sealed partial class HistoryService : IDisposable
         return entry;
     }
 
-    public HistoryEntry TrackExistingCapture(string filePath, int width, int height, HistoryKind kind = HistoryKind.Image, string? providerName = null)
+    public HistoryEntry TrackExistingCapture(string filePath, int width, int height, HistoryKind kind = HistoryKind.Image, string? providerName = null, string? sourceApp = null)
     {
         var info = new FileInfo(filePath);
         if (!info.Exists)
@@ -325,6 +327,8 @@ public sealed partial class HistoryService : IDisposable
             entry.FileSizeBytes = info.Length;
             entry.Kind = kind;
             entry.UploadProvider = providerName;
+            if (!string.IsNullOrWhiteSpace(sourceApp))
+                entry.SourceApp = sourceApp;
 
             _entries.Insert(0, entry);
             _entriesByPath[entry.FilePath] = entry;
@@ -337,7 +341,7 @@ public sealed partial class HistoryService : IDisposable
         return entry;
     }
 
-    public HistoryEntry SaveCapture(Bitmap screenshot)
+    public HistoryEntry SaveCapture(Bitmap screenshot, string? sourceApp = null)
     {
         var now = DateTime.Now;
         string ext = CaptureOutputService.GetExtension(CaptureImageFormat);
@@ -360,7 +364,8 @@ public sealed partial class HistoryService : IDisposable
                 Width = screenshot.Width,
                 Height = screenshot.Height,
                 FileSizeBytes = fileSizeBytes,
-                Kind = HistoryKind.Image
+                Kind = HistoryKind.Image,
+                SourceApp = sourceApp
             };
             _entries.Insert(0, entry);
             _entriesByPath[entry.FilePath] = entry;

--- a/src/OddSnap/Services/SettingsService.cs
+++ b/src/OddSnap/Services/SettingsService.cs
@@ -398,6 +398,7 @@ public sealed class SettingsService : IDisposable
         settings.ScrollingCaptureMode = NormalizeEnum(settings.ScrollingCaptureMode, ScrollingCaptureMode.Automatic);
         settings.HistoryRetention = NormalizeEnum(settings.HistoryRetention, HistoryRetentionPeriod.Never);
         settings.ToastPosition = NormalizeEnum(settings.ToastPosition, ToastPosition.Right);
+        settings.TrayLeftClickAction = NormalizeEnum(settings.TrayLeftClickAction, TrayClickAction.Capture);
         settings.SoundPack = NormalizeEnum(settings.SoundPack, SoundPack.Default);
         settings.RecordingFormat = NormalizeEnum(settings.RecordingFormat, RecordingFormat.MP4);
         settings.RecordingQuality = NormalizeEnum(settings.RecordingQuality, RecordingQuality.Original);

--- a/src/OddSnap/UI/Controls/OddSnapTitleBar.xaml
+++ b/src/OddSnap/UI/Controls/OddSnapTitleBar.xaml
@@ -5,7 +5,7 @@
     <Border x:Name="TitleBarBorder"
             MinHeight="40"
             Padding="14,0,0,0"
-            CornerRadius="11,11,0,0"
+            CornerRadius="{DynamicResource OddSnapTitleBarCornerRadius}"
             Background="Transparent"
             MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
         <Grid>

--- a/src/OddSnap/UI/ImageViewerWindow.xaml
+++ b/src/OddSnap/UI/ImageViewerWindow.xaml
@@ -1,0 +1,160 @@
+<Window x:Class="OddSnap.UI.ImageViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Preview"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Topmost="True"
+        Background="Transparent"
+        Icon="pack://application:,,,/Assets/oddsnap.ico"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Window.Resources>
+        <!-- Photoshop-style transparency checkerboard: also makes the edges of a screenshot
+             obvious against the backdrop. -->
+        <DrawingBrush x:Key="CheckerBrush" TileMode="Tile"
+                      Viewport="0,0,28,28" ViewportUnits="Absolute" Stretch="None">
+            <DrawingBrush.Drawing>
+                <DrawingGroup>
+                    <GeometryDrawing Brush="#FF1C1C1C">
+                        <GeometryDrawing.Geometry>
+                            <RectangleGeometry Rect="0,0,28,28"/>
+                        </GeometryDrawing.Geometry>
+                    </GeometryDrawing>
+                    <GeometryDrawing Brush="#FF262626">
+                        <GeometryDrawing.Geometry>
+                            <GeometryGroup>
+                                <RectangleGeometry Rect="0,0,14,14"/>
+                                <RectangleGeometry Rect="14,14,14,14"/>
+                            </GeometryGroup>
+                        </GeometryDrawing.Geometry>
+                    </GeometryDrawing>
+                </DrawingGroup>
+            </DrawingBrush.Drawing>
+        </DrawingBrush>
+
+        <!-- The overlay is deliberately theme-independent: it sits on a dark scrim in both themes,
+             so light-theme brushes would be unreadable here. -->
+        <Style x:Key="ViewerButton" TargetType="Button">
+            <Setter Property="FontSize" Value="11.5"/>
+            <Setter Property="Foreground" Value="#F2FFFFFF"/>
+            <Setter Property="Margin" Value="6,0,0,0"/>
+            <Setter Property="MinHeight" Value="30"/>
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd"
+                                CornerRadius="6"
+                                Background="#26FFFFFF"
+                                BorderBrush="#33FFFFFF"
+                                BorderThickness="1"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#3DFFFFFF"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#59FFFFFF"/>
+                            </Trigger>
+                            <Trigger Property="IsKeyboardFocused" Value="True">
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#B3FFFFFF"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.4"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <!-- Preview handlers: the ScrollViewer marks click and wheel events handled, so the dismiss and
+         zoom gestures have to be caught on the way down. -->
+    <Grid x:Name="Backdrop"
+          Background="{StaticResource CheckerBrush}"
+          PreviewMouseLeftButtonDown="Backdrop_PreviewMouseLeftButtonDown"
+          PreviewMouseLeftButtonUp="Backdrop_PreviewMouseLeftButtonUp"
+          PreviewMouseWheel="Backdrop_PreviewMouseWheel"
+          AutomationProperties.Name="Preview backdrop"
+          AutomationProperties.HelpText="Click outside the image, or press Escape, to close the preview.">
+
+        <ScrollViewer x:Name="ImageScroller"
+                      HorizontalScrollBarVisibility="Hidden"
+                      VerticalScrollBarVisibility="Hidden"
+                      Background="Transparent"
+                      Padding="0,56,0,64">
+            <Image x:Name="PreviewImage"
+                   Stretch="Uniform"
+                   RenderOptions.BitmapScalingMode="HighQuality"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   MouseLeftButtonDown="PreviewImage_MouseLeftButtonDown"
+                   MouseLeftButtonUp="PreviewImage_MouseLeftButtonUp"
+                   MouseMove="PreviewImage_MouseMove"
+                   AutomationProperties.Name="Capture preview"
+                   AutomationProperties.HelpText="Scroll to zoom, double-click to switch between fit and full size, and drag to pan."/>
+        </ScrollViewer>
+
+        <Border x:Name="PreviewErrorPanel"
+                Visibility="Collapsed"
+                IsHitTestVisible="False"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                Background="#E01B1B1B" CornerRadius="10" Padding="24,18">
+            <TextBlock x:Name="PreviewErrorText"
+                       FontSize="13" TextWrapping="Wrap" TextAlignment="Center"
+                       MaxWidth="460" Foreground="#F0F0F0"
+                       AutomationProperties.LiveSetting="Polite"/>
+        </Border>
+
+        <!-- Top bar: file name + zoom readout -->
+        <Border VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                Background="#B2101010" Padding="18,12" IsHitTestVisible="False">
+            <DockPanel>
+                <TextBlock x:Name="ZoomText" DockPanel.Dock="Right"
+                           FontSize="12" Foreground="#C8FFFFFF" VerticalAlignment="Center"
+                           Margin="12,0,0,0"
+                           AutomationProperties.Name="Zoom level"
+                           AutomationProperties.LiveSetting="Polite"/>
+                <TextBlock x:Name="TitleText"
+                           FontSize="13" Foreground="#FFFFFF" VerticalAlignment="Center"
+                           TextTrimming="CharacterEllipsis"
+                           AutomationProperties.Name="Capture file name"/>
+            </DockPanel>
+        </Border>
+
+        <!-- Bottom bar: metadata + actions -->
+        <Border x:Name="ActionBar" VerticalAlignment="Bottom" HorizontalAlignment="Stretch"
+                Background="#B2101010" Padding="18,10">
+            <DockPanel>
+                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
+                    <Button x:Name="ZoomBtn" Content="100%" Style="{StaticResource ViewerButton}"
+                            Click="ZoomBtn_Click"
+                            AutomationProperties.Name="Toggle zoom"/>
+                    <Button x:Name="CopyBtn" Content="Copy" Style="{StaticResource ViewerButton}"
+                            Click="CopyBtn_Click"
+                            AutomationProperties.Name="Copy image"/>
+                    <Button x:Name="ShowInFolderBtn" Content="Show in folder" Style="{StaticResource ViewerButton}"
+                            Click="ShowInFolderBtn_Click"
+                            AutomationProperties.Name="Show in folder"/>
+                    <Button x:Name="OpenExternalBtn" Content="Open in app" Style="{StaticResource ViewerButton}"
+                            Click="OpenExternalBtn_Click"
+                            AutomationProperties.Name="Open in default app"/>
+                    <Button x:Name="CloseBtn" Content="Close" Style="{StaticResource ViewerButton}"
+                            Click="CloseBtn_Click"
+                            AutomationProperties.Name="Close preview"/>
+                </WrapPanel>
+                <TextBlock x:Name="MetadataText" FontSize="11.5" Foreground="#A8FFFFFF"
+                           VerticalAlignment="Center" Margin="0,0,12,0"
+                           TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"
+                           AutomationProperties.Name="Capture details"
+                           AutomationProperties.LiveSetting="Polite"/>
+            </DockPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/src/OddSnap/UI/ImageViewerWindow.xaml.cs
+++ b/src/OddSnap/UI/ImageViewerWindow.xaml.cs
@@ -1,0 +1,488 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+using OddSnap.Helpers;
+using OddSnap.Services;
+using Cursors = System.Windows.Input.Cursors;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+using MouseEventArgs = System.Windows.Input.MouseEventArgs;
+using Point = System.Windows.Point;
+
+namespace OddSnap.UI;
+
+/// <summary>
+/// ShareX-style fullscreen lightbox for history captures. The image sits on a dimmed scrim at 100%
+/// when it fits and zoomed-to-fit when it doesn't; clicking anywhere off the image closes it.
+/// Opening a saved capture stays inside OddSnap instead of handing the file to Photos.
+/// </summary>
+public partial class ImageViewerWindow : Window
+{
+    private const double MinZoom = 0.05;
+    private const double MaxZoom = 8.0;
+    private const double ZoomStep = 1.15;
+
+    /// <summary>Chrome height reserved at the top and bottom by the info bars.</summary>
+    private const double TopChromeHeight = 64;
+    private const double BottomChromeHeight = 72;
+
+    private readonly List<HistoryEntry> _entries;
+    private int _index;
+    private double _fitZoom = 1.0;
+    private double _zoom = 1.0;
+    private bool _isClosed;
+    private bool _isClosing;
+    private bool _dismissOnMouseUp;
+
+    private bool _isPanning;
+    private Point _panStart;
+    private double _panStartHorizontalOffset;
+    private double _panStartVerticalOffset;
+
+    private ImageViewerWindow(IReadOnlyList<HistoryEntry> entries, int startIndex)
+    {
+        _entries = entries.ToList();
+        _index = Math.Clamp(startIndex, 0, Math.Max(0, _entries.Count - 1));
+
+        InitializeComponent();
+        LocalizationService.ApplyTo(this);
+
+        Closed += (_, _) =>
+        {
+            _isClosed = true;
+            _isClosing = true;
+        };
+        Closing += (_, _) => _isClosing = true;
+        SizeChanged += (_, _) => RecomputeFitAndApply(keepUserZoom: true);
+        Loaded += (_, _) =>
+        {
+            Backdrop.Focus();
+            ShowCurrentEntry();
+        };
+    }
+
+    /// <summary>Opens the viewer for <paramref name="entries"/>[<paramref name="startIndex"/>].</summary>
+    public static bool TryShow(Window? owner, IReadOnlyList<HistoryEntry> entries, int startIndex)
+    {
+        if (entries.Count == 0)
+            return false;
+
+        try
+        {
+            var window = new ImageViewerWindow(entries, startIndex);
+            if (owner is not null && !ReferenceEquals(owner, window))
+                window.Owner = owner;
+
+            window.CoverScreenOf(owner);
+            window.Show();
+            window.Activate();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogError("image-viewer.open", ex);
+            ToastWindow.ShowError(
+                "Preview failed",
+                $"OddSnap could not open the preview. Try opening the file from History instead.\n{ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Fills the monitor the preview was opened from. Centering on the owner first makes WPF pick
+    /// that monitor, then maximizing snaps to it — no manual DPI arithmetic to get wrong.
+    /// </summary>
+    private void CoverScreenOf(Window? owner)
+    {
+        WindowStartupLocation = owner is not null
+            ? WindowStartupLocation.CenterOwner
+            : WindowStartupLocation.CenterScreen;
+        WindowState = WindowState.Maximized;
+    }
+
+    /// <summary>
+    /// The only way this window closes. WPF throws if <see cref="Window.Close"/> is re-entered while
+    /// a close is already running, which is exactly what happens when a backdrop click closes the
+    /// window and the resulting deactivation tries to close it again.
+    /// </summary>
+    private void RequestClose()
+    {
+        if (_isClosing || _isClosed)
+            return;
+
+        _isClosing = true;
+        Close();
+    }
+
+    private HistoryEntry Current => _entries[_index];
+
+    private void ShowCurrentEntry()
+    {
+        if (_isClosed)
+            return;
+
+        var entry = Current;
+        var fileName = string.IsNullOrWhiteSpace(entry.FileName)
+            ? Path.GetFileName(entry.FilePath)
+            : entry.FileName;
+        Title = fileName;
+        TitleText.Text = _entries.Count > 1
+            ? $"{fileName}   ({_index + 1} of {_entries.Count})"
+            : fileName;
+
+        var source = TryLoadImage(entry.FilePath, out var errorMessage);
+        PreviewImage.Source = source;
+        PreviewImage.Visibility = source is null ? Visibility.Collapsed : Visibility.Visible;
+        PreviewErrorPanel.Visibility = source is null ? Visibility.Visible : Visibility.Collapsed;
+        PreviewErrorText.Text = errorMessage ?? "";
+
+        var hasImage = source is not null;
+        CopyBtn.IsEnabled = hasImage;
+        ZoomBtn.IsEnabled = hasImage;
+        ShowInFolderBtn.IsEnabled = !string.IsNullOrWhiteSpace(entry.FilePath);
+        OpenExternalBtn.IsEnabled = !string.IsNullOrWhiteSpace(entry.FilePath);
+
+        RecomputeFitAndApply(keepUserZoom: false);
+        UpdateMetadataText(entry, source);
+    }
+
+    // ─── Zoom ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Recomputes the fit-to-screen scale. Images smaller than the viewport show at 100%; larger
+    /// ones shrink to fit, so every capture is viewable without touching a control.
+    /// </summary>
+    private void RecomputeFitAndApply(bool keepUserZoom)
+    {
+        if (PreviewImage.Source is not BitmapSource source)
+        {
+            ZoomText.Text = "";
+            return;
+        }
+
+        double viewportWidth = Math.Max(1, ActualWidth - 32);
+        double viewportHeight = Math.Max(1, ActualHeight - TopChromeHeight - BottomChromeHeight);
+        double scale = Math.Min(viewportWidth / source.Width, viewportHeight / source.Height);
+
+        // Never blow small images up just to fill the screen — 100% is the natural resting size.
+        _fitZoom = Math.Clamp(Math.Min(scale, 1.0), MinZoom, MaxZoom);
+
+        if (!keepUserZoom || _zoom <= 0)
+            _zoom = _fitZoom;
+
+        ApplyZoom();
+    }
+
+    private void ApplyZoom()
+    {
+        if (PreviewImage.Source is not BitmapSource source)
+            return;
+
+        _zoom = Math.Clamp(_zoom, MinZoom, MaxZoom);
+        PreviewImage.Width = Math.Max(1, source.Width * _zoom);
+        PreviewImage.Height = Math.Max(1, source.Height * _zoom);
+
+        // Scrollbars stay hidden: panning is by drag. Disabling them would clamp the image to the
+        // viewport and silently undo the zoom.
+        bool zoomedIn = _zoom > _fitZoom + 0.001;
+        PreviewImage.Cursor = zoomedIn ? Cursors.SizeAll : Cursors.Arrow;
+
+        ZoomText.Text = $"{_zoom * 100:F0}%";
+        ZoomBtn.Content = Math.Abs(_zoom - 1.0) < 0.001 ? "Fit" : "100%";
+    }
+
+    private void ZoomBy(double factor, Point? centerOnScreen = null)
+    {
+        if (PreviewImage.Source is null)
+            return;
+
+        var before = _zoom;
+        _zoom = Math.Clamp(_zoom * factor, MinZoom, MaxZoom);
+        if (Math.Abs(before - _zoom) < 0.0001)
+            return;
+
+        ApplyZoom();
+        if (centerOnScreen is { } center)
+            KeepPointAnchored(center, before);
+    }
+
+    /// <summary>Keeps the pixel under the cursor put while the scale changes.</summary>
+    private void KeepPointAnchored(Point cursorInScroller, double previousZoom)
+    {
+        if (previousZoom <= 0)
+            return;
+
+        double ratio = _zoom / previousZoom;
+        double targetX = (ImageScroller.HorizontalOffset + cursorInScroller.X) * ratio - cursorInScroller.X;
+        double targetY = (ImageScroller.VerticalOffset + cursorInScroller.Y) * ratio - cursorInScroller.Y;
+
+        ImageScroller.UpdateLayout();
+        ImageScroller.ScrollToHorizontalOffset(targetX);
+        ImageScroller.ScrollToVerticalOffset(targetY);
+    }
+
+    private void ToggleZoom()
+    {
+        if (PreviewImage.Source is null)
+            return;
+
+        _zoom = Math.Abs(_zoom - 1.0) < 0.001 ? _fitZoom : 1.0;
+        ApplyZoom();
+    }
+
+    // ─── Content ───────────────────────────────────────────────────
+
+    private void UpdateMetadataText(HistoryEntry entry, BitmapSource? source)
+    {
+        var parts = new List<string>();
+
+        int width = source?.PixelWidth ?? entry.Width;
+        int height = source?.PixelHeight ?? entry.Height;
+        if (width > 0 && height > 0)
+            parts.Add($"{width} × {height}");
+
+        var sizeBytes = entry.FileSizeBytes;
+        if (sizeBytes <= 0)
+        {
+            try
+            {
+                if (File.Exists(entry.FilePath))
+                    sizeBytes = new FileInfo(entry.FilePath).Length;
+            }
+            catch (Exception ex)
+            {
+                AppDiagnostics.LogWarning("image-viewer.size", ex.Message, ex);
+            }
+        }
+
+        if (sizeBytes > 0)
+        {
+            parts.Add(sizeBytes >= 1024 * 1024
+                ? $"{sizeBytes / 1024.0 / 1024.0:F1} MB"
+                : $"{sizeBytes / 1024.0:F0} KB");
+        }
+
+        if (entry.CapturedAt != default)
+            parts.Add(entry.CapturedAt.ToString("g"));
+
+        if (!string.IsNullOrWhiteSpace(entry.SourceApp))
+            parts.Add($"from {entry.SourceApp}");
+
+        MetadataText.Text = string.Join("  ·  ", parts);
+        AutomationProperties.SetHelpText(MetadataText, MetadataText.Text);
+    }
+
+    private static BitmapSource? TryLoadImage(string filePath, out string? errorMessage)
+    {
+        errorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+        {
+            errorMessage = "This file is no longer on disk. It may have been moved or deleted outside OddSnap.";
+            return null;
+        }
+
+        try
+        {
+            var image = new BitmapImage();
+            image.BeginInit();
+            image.UriSource = new Uri(filePath, UriKind.Absolute);
+            image.CacheOption = BitmapCacheOption.OnLoad;
+            image.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+            image.EndInit();
+            image.Freeze();
+            return image;
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning("image-viewer.load", $"Failed to load {Path.GetFileName(filePath)}: {ex.Message}", ex);
+            errorMessage = $"OddSnap could not read this image.\n{ex.Message}";
+            return null;
+        }
+    }
+
+    private void MoveBy(int delta)
+    {
+        if (_entries.Count <= 1)
+            return;
+
+        _index = (_index + delta + _entries.Count) % _entries.Count;
+        ShowCurrentEntry();
+    }
+
+    // ─── Event handlers ────────────────────────────────────────────
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Escape:
+                e.Handled = true;
+                RequestClose();
+                break;
+            case Key.Left:
+                e.Handled = true;
+                MoveBy(-1);
+                break;
+            case Key.Right:
+                e.Handled = true;
+                MoveBy(1);
+                break;
+            case Key.Add or Key.OemPlus:
+                e.Handled = true;
+                ZoomBy(ZoomStep);
+                break;
+            case Key.Subtract or Key.OemMinus:
+                e.Handled = true;
+                ZoomBy(1 / ZoomStep);
+                break;
+            case Key.D0 when (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control:
+                e.Handled = true;
+                ToggleZoom();
+                break;
+            case Key.C when (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control:
+                e.Handled = true;
+                CopyCurrentImage();
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Click-anywhere-off-the-image dismissal. This has to be a preview handler: the ScrollViewer
+    /// that hosts the image marks bubbling left-clicks handled to take focus, so a bubbling handler
+    /// on the backdrop never runs.
+    ///
+    /// The press only arms the dismissal — closing here would destroy the window mid-gesture and
+    /// let the release fall through to whatever is underneath (a history card, which would
+    /// immediately reopen the viewer).
+    /// </summary>
+    private void Backdrop_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        if (IsWithin(source, PreviewImage) || IsWithin(source, ActionBar))
+        {
+            _dismissOnMouseUp = false;
+            return;
+        }
+
+        _dismissOnMouseUp = true;
+        e.Handled = true;
+    }
+
+    private void Backdrop_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_dismissOnMouseUp)
+            return;
+
+        _dismissOnMouseUp = false;
+
+        // Dragging from the backdrop onto the image isn't a dismissal.
+        var source = e.OriginalSource as DependencyObject;
+        if (IsWithin(source, PreviewImage) || IsWithin(source, ActionBar))
+            return;
+
+        e.Handled = true;
+        RequestClose();
+    }
+
+    /// <summary>Same story as the click: the ScrollViewer consumes bubbling wheel events to scroll.</summary>
+    private void Backdrop_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        e.Handled = true;
+        ZoomBy(e.Delta > 0 ? ZoomStep : 1 / ZoomStep, e.GetPosition(ImageScroller));
+    }
+
+    private static bool IsWithin(DependencyObject? source, DependencyObject ancestor)
+    {
+        for (var node = source; node is not null; node = GetParent(node))
+        {
+            if (ReferenceEquals(node, ancestor))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static DependencyObject? GetParent(DependencyObject node) =>
+        node is System.Windows.Media.Visual or System.Windows.Media.Media3D.Visual3D
+            ? System.Windows.Media.VisualTreeHelper.GetParent(node)
+            : LogicalTreeHelper.GetParent(node);
+
+    private void PreviewImage_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        e.Handled = true;
+
+        if (e.ClickCount == 2)
+        {
+            ToggleZoom();
+            return;
+        }
+
+        if (_zoom <= _fitZoom + 0.001)
+            return;
+
+        _isPanning = true;
+        _panStart = e.GetPosition(ImageScroller);
+        _panStartHorizontalOffset = ImageScroller.HorizontalOffset;
+        _panStartVerticalOffset = ImageScroller.VerticalOffset;
+        PreviewImage.CaptureMouse();
+    }
+
+    private void PreviewImage_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isPanning)
+            return;
+
+        var current = e.GetPosition(ImageScroller);
+        ImageScroller.ScrollToHorizontalOffset(_panStartHorizontalOffset - (current.X - _panStart.X));
+        ImageScroller.ScrollToVerticalOffset(_panStartVerticalOffset - (current.Y - _panStart.Y));
+    }
+
+    private void PreviewImage_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_isPanning)
+            return;
+
+        _isPanning = false;
+        PreviewImage.ReleaseMouseCapture();
+        e.Handled = true;
+    }
+
+    private void ZoomBtn_Click(object sender, RoutedEventArgs e) => ToggleZoom();
+
+    private void CloseBtn_Click(object sender, RoutedEventArgs e) => RequestClose();
+
+    private void CopyBtn_Click(object sender, RoutedEventArgs e) => CopyCurrentImage();
+
+    private void CopyCurrentImage()
+    {
+        var filePath = Current.FilePath;
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                ToastWindow.ShowError("Copy failed", "This file is no longer on disk.", filePath);
+                return;
+            }
+
+            using var bitmap = BitmapPerf.LoadDetached(filePath);
+            ClipboardService.CopyToClipboard(bitmap, filePath);
+            ToastWindow.Show("Copied", "Image copied to clipboard");
+        }
+        catch (Exception ex)
+        {
+            ToastWindow.ShowError(
+                "Copy failed",
+                $"OddSnap could not copy this image. Try again, or copy it from History.\n{ex.Message}",
+                filePath);
+        }
+    }
+
+    private void ShowInFolderBtn_Click(object sender, RoutedEventArgs e)
+        => SettingsWindow.ShowHistoryFileInFolder(Current.FilePath);
+
+    private void OpenExternalBtn_Click(object sender, RoutedEventArgs e)
+        => SettingsWindow.OpenHistoryFileWithDefaultApp(Current.FilePath);
+}

--- a/src/OddSnap/UI/OcrResultWindow.xaml
+++ b/src/OddSnap/UI/OcrResultWindow.xaml
@@ -92,7 +92,7 @@
         </Style>
     </Window.Resources>
 
-    <Border x:Name="RootBorder" CornerRadius="12" ClipToBounds="True">
+    <Border x:Name="RootBorder" CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" ClipToBounds="True">
         <Border.Effect>
             <DropShadowEffect BlurRadius="24" ShadowDepth="2" Opacity="0.4" Color="Black"/>
         </Border.Effect>

--- a/src/OddSnap/UI/OddSnapWindowChrome.cs
+++ b/src/OddSnap/UI/OddSnapWindowChrome.cs
@@ -9,16 +9,89 @@ public static class OddSnapWindowChrome
 {
     private const double DefaultCornerRadius = 12;
 
+    /// <summary>
+    /// Whether OddSnap windows use rounded corners. Set from <c>AppSettings.UseRoundedCorners</c>
+    /// during startup and whenever the setting changes; windows opened afterwards pick it up, and
+    /// <see cref="Changed"/> lets open windows re-square themselves.
+    /// </summary>
+    public static bool RoundedCornersEnabled { get; private set; } = true;
+
+    /// <summary>Raised after <see cref="RoundedCornersEnabled"/> flips.</summary>
+    public static event Action? Changed;
+
+    /// <summary>Resource key XAML window roots bind their <c>CornerRadius</c> to.</summary>
+    public const string WindowCornerRadiusKey = "OddSnapWindowCornerRadius";
+
+    /// <summary>Resource key for the smaller radius used by cards and inner surfaces.</summary>
+    public const string CardCornerRadiusKey = "OddSnapCardCornerRadius";
+
+    /// <summary>Resource key for the title bar, which only rounds its top two corners.</summary>
+    public const string TitleBarCornerRadiusKey = "OddSnapTitleBarCornerRadius";
+
+    /// <summary>Resource key for the title bar close button, which only rounds its top-right corner.</summary>
+    public const string TitleCloseCornerRadiusKey = "OddSnapTitleCloseCornerRadius";
+
+    /// <summary>Resource key for progress bars, which round only their bottom corners.</summary>
+    public const string ProgressCornerRadiusKey = "OddSnapProgressCornerRadius";
+
+    public static void SetRoundedCornersEnabled(bool enabled)
+    {
+        bool changed = RoundedCornersEnabled != enabled;
+        RoundedCornersEnabled = enabled;
+        PublishCornerResources();
+        if (!changed)
+            return;
+
+        RefreshOpenWindows();
+        Changed?.Invoke();
+    }
+
+    /// <summary>Pushes the corner radii into app resources so XAML picks them up via DynamicResource.</summary>
+    public static void PublishCornerResources()
+    {
+        var app = System.Windows.Application.Current;
+        if (app is null)
+            return;
+
+        app.Resources[WindowCornerRadiusKey] = WindowRadius();
+        app.Resources[CardCornerRadiusKey] = RadiusFor(8);
+        app.Resources[TitleBarCornerRadiusKey] = RoundedCornersEnabled
+            ? new CornerRadius(11, 11, 0, 0)
+            : new CornerRadius(0);
+        app.Resources[TitleCloseCornerRadiusKey] = RoundedCornersEnabled
+            ? new CornerRadius(0, 11, 0, 0)
+            : new CornerRadius(0);
+        app.Resources[ProgressCornerRadiusKey] = RoundedCornersEnabled
+            ? new CornerRadius(0, 0, 14, 14)
+            : new CornerRadius(0);
+    }
+
+    /// <summary>Radius for a history card, so the grid squares off with the rest of the chrome.</summary>
+    public static double CardRadius() => RoundedCornersEnabled ? 8 : 0;
+
+    /// <summary>Corner radius to use for a window root border, honouring the user's preference.</summary>
+    public static CornerRadius RadiusFor(double preferred)
+        => new(RoundedCornersEnabled ? preferred : 0);
+
+    public static CornerRadius WindowRadius() => RadiusFor(DefaultCornerRadius);
+
     public static void Apply(Window window)
     {
-        WindowChrome.SetWindowChrome(window, new WindowChrome
+        void ApplyWindowChrome()
         {
-            CaptionHeight = 0,
-            CornerRadius = new CornerRadius(DefaultCornerRadius),
-            GlassFrameThickness = new Thickness(0),
-            ResizeBorderThickness = new Thickness(8),
-            UseAeroCaptionButtons = false
-        });
+            WindowChrome.SetWindowChrome(window, new WindowChrome
+            {
+                CaptionHeight = 0,
+                CornerRadius = WindowRadius(),
+                GlassFrameThickness = new Thickness(0),
+                ResizeBorderThickness = new Thickness(8),
+                UseAeroCaptionButtons = false
+            });
+        }
+
+        ApplyWindowChrome();
+        Changed += ApplyWindowChrome;
+        window.Closed += (_, _) => Changed -= ApplyWindowChrome;
 
         ApplyRoundedCorners(window, DefaultCornerRadius);
     }
@@ -31,22 +104,50 @@ public static class OddSnapWindowChrome
             if (hwnd == IntPtr.Zero)
                 return;
 
-            Dwm.TrySetWindowCornerPreference(hwnd, Dwm.DWMWCP_ROUND);
+            Dwm.TrySetWindowCornerPreference(
+                hwnd,
+                RoundedCornersEnabled ? Dwm.DWMWCP_ROUND : Dwm.DWMWCP_DONOTROUND);
             Dwm.TrySetImmersiveDarkMode(hwnd, Theme.IsDark);
             if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
                 return;
+
+            if (!RoundedCornersEnabled)
+            {
+                User32.SetWindowRgn(hwnd, IntPtr.Zero, true);
+                return;
+            }
 
             SetRoundedWindowRegion(window, hwnd, radius);
         }
 
         window.SourceInitialized += (_, _) => ApplyCurrentRegion();
         window.SizeChanged += (_, _) => ApplyCurrentRegion();
+        Changed += ApplyCurrentRegion;
         window.Closed += (_, _) =>
         {
+            Changed -= ApplyCurrentRegion;
             var hwnd = new WindowInteropHelper(window).Handle;
             if (hwnd != IntPtr.Zero)
                 User32.SetWindowRgn(hwnd, IntPtr.Zero, true);
         };
+    }
+
+    private static void RefreshOpenWindows()
+    {
+        var app = System.Windows.Application.Current;
+        if (app is null)
+            return;
+
+        foreach (Window window in app.Windows)
+        {
+            var hwnd = new WindowInteropHelper(window).Handle;
+            if (hwnd == IntPtr.Zero)
+                continue;
+
+            Dwm.TrySetWindowCornerPreference(
+                hwnd,
+                RoundedCornersEnabled ? Dwm.DWMWCP_ROUND : Dwm.DWMWCP_DONOTROUND);
+        }
     }
 
     private static void SetRoundedWindowRegion(Window window, IntPtr hwnd, double radius)

--- a/src/OddSnap/UI/PreviewWindow.xaml
+++ b/src/OddSnap/UI/PreviewWindow.xaml
@@ -13,7 +13,7 @@
         MouseLeave="OnMouseLeave">
 
     <Border x:Name="ImageBorder" MinWidth="120" MinHeight="80"
-            CornerRadius="18" Background="#12000000"
+            CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" Background="#12000000"
             BorderBrush="#D8FFFFFF" BorderThickness="2">
         <Border.Effect>
             <DropShadowEffect BlurRadius="32" ShadowDepth="6" Opacity="0.4" Color="Black"/>
@@ -93,7 +93,7 @@
 
             <Border x:Name="ProgressBar" Grid.Row="1" Height="2"
                     Margin="4,0,4,4"
-                    Background="#55FFFFFF" CornerRadius="0,0,14,14"
+                    Background="#55FFFFFF" CornerRadius="{DynamicResource OddSnapProgressCornerRadius}"
                     HorizontalAlignment="Stretch"
                     RenderTransformOrigin="0,0.5">
                 <Border.RenderTransform>

--- a/src/OddSnap/UI/PreviewWindow.xaml.cs
+++ b/src/OddSnap/UI/PreviewWindow.xaml.cs
@@ -340,9 +340,11 @@ public partial class PreviewWindow : Window
         if (PreviewFrame.ActualWidth <= 0 || PreviewFrame.ActualHeight <= 0)
             return;
 
+        var radius = OddSnapWindowChrome.RoundedCornersEnabled ? PreviewCornerRadius : 0;
+        PreviewFrame.CornerRadius = new CornerRadius(radius);
         ImageClip.Rect = new System.Windows.Rect(0, 0, PreviewFrame.ActualWidth, PreviewFrame.ActualHeight);
-        ImageClip.RadiusX = PreviewCornerRadius;
-        ImageClip.RadiusY = PreviewCornerRadius;
+        ImageClip.RadiusX = radius;
+        ImageClip.RadiusY = radius;
     }
 
     private void SetThumbnail()

--- a/src/OddSnap/UI/Settings/History/SettingsWindow.History.cs
+++ b/src/OddSnap/UI/Settings/History/SettingsWindow.History.cs
@@ -865,6 +865,7 @@ public partial class SettingsWindow
         }
 
         image.Source = vm.ThumbnailSource ?? GetHistoryPlaceholder(vm.Entry.Kind);
+        ApplyThumbnailStretch(image);
         image.Opacity = 1;
 
         if (!vm.ThumbnailLoaded || vm.ThumbnailSource is null || IsStaleHistoryPlaceholder(vm.ThumbnailSource, vm.Entry.Kind))

--- a/src/OddSnap/UI/Settings/Media/SettingsWindow.MediaCard.cs
+++ b/src/OddSnap/UI/Settings/Media/SettingsWindow.MediaCard.cs
@@ -18,7 +18,7 @@ namespace OddSnap.UI;
 
 public partial class SettingsWindow
 {
-    private sealed record MediaCardShell(Border Card, Grid ImageContainer, StackPanel InfoPanel, Border CopyButton, System.Windows.Controls.Image Image, Border SelectionBadge);
+    private sealed record MediaCardShell(Border Card, Grid ImageContainer, StackPanel InfoPanel, System.Windows.Controls.Image Image, Border SelectionBadge);
 
     private static bool IsDraggableFile(string? path) =>
         !string.IsNullOrWhiteSpace(path) && File.Exists(path);
@@ -64,125 +64,41 @@ public partial class SettingsWindow
         };
         vm.ThumbnailImage = img;
         img.Source = vm.ThumbnailSource ?? GetHistoryPlaceholder(vm.Entry.Kind);
+        ApplyThumbnailStretch(img);
         RenderOptions.SetBitmapScalingMode(img, BitmapScalingMode.HighQuality);
 
         img.Loaded += (_, _) => RefreshCardThumbnail(vm);
 
-        var actionMenuBtn = new Border
-        {
-            Width = 40,
-            Height = 40,
-            CornerRadius = new CornerRadius(8),
-            Background = new SolidColorBrush(System.Windows.Media.Color.FromArgb(180, 0, 0, 0)),
-            BorderBrush = new SolidColorBrush(System.Windows.Media.Color.FromArgb(210, 255, 255, 255)),
-            BorderThickness = new Thickness(1),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 8, 8, 0),
-            Cursor = Cursors.Hand,
-            Opacity = 0,
-            IsHitTestVisible = true,
-            Focusable = true,
-            ToolTip = "Open history item actions",
-            Child = new TextBlock
-            {
-                Text = "⋯",
-                Foreground = Brushes.White,
-                FontSize = 20,
-                FontWeight = FontWeights.SemiBold,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-            }
-        };
-        AutomationProperties.SetName(actionMenuBtn, $"{kindLabel} actions");
-        AutomationProperties.SetHelpText(actionMenuBtn, "Press Enter or Space to open this history item's actions.");
-
         var actionMenu = CreateCardActionMenu();
         var hasUploadUrl = !string.IsNullOrWhiteSpace(vm.Entry.UploadUrl);
-        actionMenu.Items.Add(CreateCardActionMenuItem(GetHistoryCopyMenuLabel(vm.Entry), () =>
-        {
-            suppressOpenAction = true;
-            copyAction();
-        }, GetHistoryCopyMenuHelpText(vm.Entry, kindLabel)));
+        actionMenu.Items.Add(CreateCardActionMenuItem(
+            GetHistoryCopyMenuLabel(vm.Entry),
+            copyAction,
+            GetHistoryCopyMenuHelpText(vm.Entry, kindLabel)));
         if (hasUploadUrl)
         {
-            actionMenu.Items.Add(CreateCardActionMenuItem(GetHistoryOpenUrlMenuLabel(vm.Entry), () =>
-            {
-                suppressOpenAction = true;
-                OpenExternal(vm.Entry.UploadUrl!);
-            }, GetHistoryOpenUrlMenuHelpText(vm.Entry)));
+            actionMenu.Items.Add(CreateCardActionMenuItem(
+                GetHistoryOpenUrlMenuLabel(vm.Entry),
+                () => OpenExternal(vm.Entry.UploadUrl!),
+                GetHistoryOpenUrlMenuHelpText(vm.Entry)));
         }
         if (IsDraggableFile(vm.Entry.FilePath))
         {
-            var uploadInProgress = IsHistoryUploadInProgress(vm.Entry.FilePath);
-            var uploadHelpText = GetHistoryUploadMenuHelpText(vm.Entry, uploadInProgress);
             MenuItem? uploadItem = null;
-            uploadItem = CreateCardActionMenuItem(GetHistoryUploadMenuLabel(vm.Entry, uploadInProgress), () =>
-            {
-                suppressOpenAction = true;
-                if (uploadItem is not null)
-                {
-                    uploadItem.Header = "Uploading...";
-                    uploadItem.ToolTip = "This history item upload is already running.";
-                    AutomationProperties.SetName(uploadItem, "Uploading history item");
-                    AutomationProperties.SetHelpText(uploadItem, "This history item upload is already running.");
-                    uploadItem.IsEnabled = false;
-                }
-                _ = RetryHistoryUploadAsync(vm);
-            }, uploadHelpText);
-            uploadItem.IsEnabled = !uploadInProgress;
-            if (uploadInProgress)
-            {
-                AutomationProperties.SetName(uploadItem, "Uploading history item");
-                AutomationProperties.SetHelpText(uploadItem, uploadHelpText);
-            }
+            uploadItem = CreateCardActionMenuItem(
+                GetHistoryUploadMenuLabel(vm.Entry, IsHistoryUploadInProgress(vm.Entry.FilePath)),
+                () => _ = RunHistoryUploadFromMenuAsync(vm, uploadItem!),
+                GetHistoryUploadMenuHelpText(vm.Entry, IsHistoryUploadInProgress(vm.Entry.FilePath)));
+            UpdateHistoryUploadMenuItem(uploadItem, vm);
             actionMenu.Items.Add(uploadItem);
         }
         if (HasHistoryFilePath(vm.Entry.FilePath))
         {
-            actionMenu.Items.Add(CreateCardActionMenuItem("Show in folder", () =>
-            {
-                suppressOpenAction = true;
-                ShowFileInFolder(vm.Entry.FilePath);
-            }, "Show this file in File Explorer."));
+            actionMenu.Items.Add(CreateCardActionMenuItem(
+                "Show in folder",
+                () => ShowFileInFolder(vm.Entry.FilePath),
+                "Show this file in File Explorer."));
         }
-
-        actionMenuBtn.ContextMenu = actionMenu;
-        void OpenActionMenu()
-        {
-            suppressOpenAction = true;
-            actionMenuBtn.BeginAnimation(OpacityProperty, Motion.To(1, 100, Motion.SmoothOut));
-            actionMenu.PlacementTarget = actionMenuBtn;
-            actionMenu.IsOpen = true;
-        }
-
-        actionMenuBtn.PreviewMouseLeftButtonUp += (_, e) =>
-        {
-            e.Handled = true;
-            OpenActionMenu();
-        };
-        actionMenuBtn.KeyDown += (_, e) =>
-        {
-            if (!IsHistoryCardActivationKey(e))
-                return;
-
-            e.Handled = true;
-            OpenActionMenu();
-        };
-        actionMenuBtn.GotKeyboardFocus += (_, _) =>
-        {
-            actionMenuBtn.BeginAnimation(OpacityProperty, Motion.To(1, 100, Motion.SmoothOut));
-        };
-        actionMenuBtn.LostKeyboardFocus += (_, _) =>
-        {
-            if (!actionMenu.IsOpen)
-                actionMenuBtn.BeginAnimation(OpacityProperty, Motion.To(0, 120, Motion.SmoothOut));
-        };
-        actionMenu.Closed += (_, _) =>
-        {
-            if (!actionMenuBtn.IsKeyboardFocusWithin && !actionMenuBtn.IsMouseOver)
-                actionMenuBtn.BeginAnimation(OpacityProperty, Motion.To(0, 120, Motion.SmoothOut));
-        };
 
         var selectionBadge = CreateSelectionBadge(vm.IsSelected);
 
@@ -194,7 +110,6 @@ public partial class SettingsWindow
         var imgContainer = new Grid();
         imgContainer.Children.Add(img);
         imgContainer.Children.Add(selectionBadge);
-        imgContainer.Children.Add(actionMenuBtn);
         Grid.SetRow(imgContainer, 0);
         root.Children.Add(imgContainer);
 
@@ -209,57 +124,56 @@ public partial class SettingsWindow
             MinWidth = HistoryCardMinWidth,
             MaxWidth = HistoryCardMaxWidth,
             Margin = new Thickness(HistoryCardMargin),
-            CornerRadius = new CornerRadius(8),
+            CornerRadius = new CornerRadius(OddSnapWindowChrome.CardRadius()),
             Background = Theme.Brush(Theme.BgCard),
             BorderBrush = Brushes.Transparent,
             BorderThickness = new Thickness(1),
             Cursor = Cursors.Hand,
             Focusable = true,
-            ToolTip = $"Open this {kindLabel} history item",
+            ToolTip = $"Open this {kindLabel} history item. Right-click for actions.",
             Child = root,
             Tag = vm,
+            ContextMenu = actionMenu,
         };
         AutomationProperties.SetName(card, $"{kindLabel} history item");
-        AutomationProperties.SetHelpText(card, "Press Enter or Space to open this history item. Press Ctrl+C to copy it or its upload link. In select mode, press Enter or Space to select it.");
+        AutomationProperties.SetHelpText(card, "Press Enter or Space to open this history item. Right-click or press the Menu key for its actions. Press Ctrl+C to copy it or its upload link. In select mode, press Enter or Space to select it.");
 
-        card.SizeChanged += (s, _) =>
+        // Resizing the window re-widths every visible card, so this runs on every drag frame for
+        // every card. Allocating a fresh geometry and re-setting the row height each time was the
+        // bulk of the resize stutter in History — reuse the clip and only write real changes.
+        var cardRadius = OddSnapWindowChrome.CardRadius();
+        var cardClip = new System.Windows.Media.RectangleGeometry
+        {
+            RadiusX = cardRadius,
+            RadiusY = cardRadius
+        };
+        card.Clip = cardClip;
+        card.SizeChanged += (s, e) =>
         {
             var b = (Border)s!;
-            imageRow.Height = new GridLength(GetHistoryCardImageHeight(b.ActualWidth));
-            b.Clip = new System.Windows.Media.RectangleGeometry(
-                new System.Windows.Rect(0, 0, b.ActualWidth, b.ActualHeight), 8, 8);
+            if (e.WidthChanged)
+            {
+                var imageHeight = GetHistoryCardImageHeight(b.ActualWidth);
+                if (Math.Abs(imageRow.Height.Value - imageHeight) > 0.5)
+                    imageRow.Height = new GridLength(imageHeight);
+            }
+
+            cardClip.Rect = new System.Windows.Rect(0, 0, b.ActualWidth, b.ActualHeight);
         };
 
-        card.MouseEnter += (s, _) =>
-        {
-            card.BorderBrush = cardFocusBrush;
-            actionMenuBtn.BeginAnimation(OpacityProperty,
-                Motion.To(1, 150, Motion.SmoothOut));
-        };
-        card.MouseLeave += (s, _) =>
+        card.MouseEnter += (_, _) => card.BorderBrush = cardFocusBrush;
+        card.MouseLeave += (_, _) =>
         {
             if (!card.IsKeyboardFocusWithin)
                 card.BorderBrush = Brushes.Transparent;
-
-            if (!card.IsKeyboardFocusWithin && !actionMenu.IsOpen)
-            {
-                actionMenuBtn.BeginAnimation(OpacityProperty,
-                    Motion.To(0, 150, Motion.SmoothOut));
-            }
         };
-        card.GotKeyboardFocus += (_, _) =>
-        {
-            card.BorderBrush = cardFocusBrush;
-            actionMenuBtn.BeginAnimation(OpacityProperty, Motion.To(1, 100, Motion.SmoothOut));
-        };
+        card.GotKeyboardFocus += (_, _) => card.BorderBrush = cardFocusBrush;
         card.LostKeyboardFocus += (_, _) =>
         {
             if (card.IsKeyboardFocusWithin || actionMenu.IsOpen)
                 return;
 
             card.BorderBrush = Brushes.Transparent;
-            if (!card.IsMouseOver)
-                actionMenuBtn.BeginAnimation(OpacityProperty, Motion.To(0, 120, Motion.SmoothOut));
         };
 
         void ActivateCard(RoutedEventArgs e)
@@ -273,7 +187,7 @@ public partial class SettingsWindow
 
             if (!_selectMode)
             {
-                OpenFileWithDefaultApp(vm.Entry.FilePath);
+                OpenHistoryItem(vm);
                 e.Handled = true;
                 return;
             }
@@ -333,7 +247,40 @@ public partial class SettingsWindow
         vm.SelectionBadge = selectionBadge;
         UpdateCardSelection(vm);
 
-        return new MediaCardShell(card, imgContainer, info, actionMenuBtn, img, selectionBadge);
+        return new MediaCardShell(card, imgContainer, info, img, selectionBadge);
+    }
+
+    /// <summary>
+    /// Runs a history upload from the card menu, restoring the menu item afterwards. The item used
+    /// to be flipped to "Uploading..." optimistically and never put back, so an upload that was
+    /// refused outright — no destination configured, for instance — left the card stuck showing
+    /// "Uploading..." with the action disabled for the rest of the session.
+    /// </summary>
+    private async Task RunHistoryUploadFromMenuAsync(HistoryItemVM vm, MenuItem uploadItem)
+    {
+        UpdateHistoryUploadMenuItem(uploadItem, vm, isUploadInProgress: true);
+        try
+        {
+            await RetryHistoryUploadAsync(vm);
+        }
+        finally
+        {
+            UpdateHistoryUploadMenuItem(uploadItem, vm);
+        }
+    }
+
+    /// <summary>Syncs the upload menu item's label, tooltip and enabled state with the real state.</summary>
+    private void UpdateHistoryUploadMenuItem(MenuItem uploadItem, HistoryItemVM vm, bool? isUploadInProgress = null)
+    {
+        var inProgress = isUploadInProgress ?? IsHistoryUploadInProgress(vm.Entry.FilePath);
+        var label = GetHistoryUploadMenuLabel(vm.Entry, inProgress);
+        var helpText = GetHistoryUploadMenuHelpText(vm.Entry, inProgress);
+
+        uploadItem.Header = label;
+        uploadItem.ToolTip = helpText;
+        uploadItem.IsEnabled = !inProgress;
+        AutomationProperties.SetName(uploadItem, label);
+        AutomationProperties.SetHelpText(uploadItem, helpText);
     }
 
     private static string GetHistoryUploadMenuLabel(HistoryEntry entry, bool isUploadInProgress)
@@ -519,6 +466,39 @@ public partial class SettingsWindow
             ? "This history item is selected."
             : "Shows whether this history item is selected in select mode.");
     }
+
+    /// <summary>
+    /// Opening a history card shows the in-app preview for still images; videos and GIFs still go to
+    /// the system player, which handles playback we don't.
+    /// </summary>
+    private void OpenHistoryItem(HistoryItemVM vm)
+    {
+        if (vm.Entry.Kind is not (HistoryKind.Image or HistoryKind.Sticker))
+        {
+            OpenFileWithDefaultApp(vm.Entry.FilePath);
+            return;
+        }
+
+        var siblings = GetCurrentHistorySelectionItems()
+            .Where(item => item.Entry.Kind is HistoryKind.Image or HistoryKind.Sticker)
+            .Select(item => item.Entry)
+            .ToList();
+
+        var index = siblings.FindIndex(entry =>
+            string.Equals(entry.FilePath, vm.Entry.FilePath, StringComparison.OrdinalIgnoreCase));
+        if (index < 0)
+        {
+            siblings = new List<HistoryEntry> { vm.Entry };
+            index = 0;
+        }
+
+        if (!ImageViewerWindow.TryShow(this, siblings, index))
+            OpenFileWithDefaultApp(vm.Entry.FilePath);
+    }
+
+    internal static bool ShowHistoryFileInFolder(string filePath) => ShowFileInFolder(filePath);
+
+    internal static bool OpenHistoryFileWithDefaultApp(string filePath) => OpenFileWithDefaultApp(filePath);
 
     private static bool ShowFileInFolder(string filePath)
     {

--- a/src/OddSnap/UI/Settings/Media/SettingsWindow.MediaHelpers.cs
+++ b/src/OddSnap/UI/Settings/Media/SettingsWindow.MediaHelpers.cs
@@ -255,6 +255,42 @@ public partial class SettingsWindow
             ? ImagePlaceholder.Value
             : VideoPlaceholder.Value;
 
+    /// <summary>
+    /// How far a capture's shape may stray from the card's before cropping it to fill stops making
+    /// sense. Inside this, crop-to-fill keeps the grid tidy; beyond it, filling would show a sliver
+    /// of a wide strip, so the thumbnail is letterboxed and you see the whole capture instead.
+    /// </summary>
+    private const double HistoryThumbnailFillAspectTolerance = 1.5;
+
+    private static readonly double HistoryCardImageAreaAspect = HistoryCardPreferredWidth / 100d;
+
+    private static void ApplyThumbnailStretch(System.Windows.Controls.Image image)
+    {
+        image.Stretch = ShouldLetterboxThumbnail(image.Source)
+            ? Stretch.Uniform
+            : Stretch.UniformToFill;
+    }
+
+    private static bool ShouldLetterboxThumbnail(ImageSource? source)
+    {
+        // Placeholders are icons, not captures — they are drawn to fill on purpose.
+        if (source is null ||
+            ReferenceEquals(source, ImagePlaceholder.Value) ||
+            ReferenceEquals(source, VideoPlaceholder.Value))
+        {
+            return false;
+        }
+
+        if (source.Width <= 0 || source.Height <= 0)
+            return false;
+
+        var aspect = source.Width / source.Height;
+        var divergence = aspect > HistoryCardImageAreaAspect
+            ? aspect / HistoryCardImageAreaAspect
+            : HistoryCardImageAreaAspect / aspect;
+        return divergence > HistoryThumbnailFillAspectTolerance;
+    }
+
     private static bool IsStaleHistoryPlaceholder(BitmapSource? source, HistoryKind kind) =>
         source is not null &&
         (kind == HistoryKind.Image || kind == HistoryKind.Gif || kind == HistoryKind.Sticker || kind == HistoryKind.Video) &&

--- a/src/OddSnap/UI/Settings/Media/SettingsWindow.MediaHistory.cs
+++ b/src/OddSnap/UI/Settings/Media/SettingsWindow.MediaHistory.cs
@@ -326,7 +326,8 @@ public partial class SettingsWindow
             }
         });
 
-        shell.Image.Stretch = Stretch.UniformToFill;
+        // Stretch is chosen per thumbnail once its dimensions are known — see ApplyThumbnailStretch.
+        ApplyThumbnailStretch(shell.Image);
 
         if (!string.IsNullOrEmpty(vm.Entry.UploadProvider))
         {
@@ -844,6 +845,7 @@ public partial class SettingsWindow
         if (vm.ThumbnailLoaded && vm.ThumbnailSource != null && !IsStaleHistoryPlaceholder(vm.ThumbnailSource, vm.Entry.Kind))
         {
             img.Source = vm.ThumbnailSource;
+            ApplyThumbnailStretch(img);
             img.Opacity = 1;
             return;
         }
@@ -856,6 +858,7 @@ public partial class SettingsWindow
             vm.ThumbnailSource = cached;
             vm.ThumbnailLoaded = true;
             img.Source = cached;
+            ApplyThumbnailStretch(img);
             img.Opacity = 1;
             ApplyThumbnailToWaiters(cacheKey, cached, animate: false);
             return;
@@ -866,6 +869,7 @@ public partial class SettingsWindow
             vm.ThumbnailSource = cachedDisk;
             vm.ThumbnailLoaded = true;
             img.Source = cachedDisk;
+            ApplyThumbnailStretch(img);
             img.Opacity = 1;
             ApplyThumbnailToWaiters(cacheKey, cachedDisk, animate: false);
             return;
@@ -1080,6 +1084,7 @@ public partial class SettingsWindow
         _ = TryPostToImageDispatcher(image, () =>
         {
             image.Source = bitmap;
+            ApplyThumbnailStretch(image);
             image.Opacity = 1;
             if (animate)
             {
@@ -1121,6 +1126,7 @@ public partial class SettingsWindow
             _ = TryPostToImageDispatcher(target, () =>
             {
                 target.Source = bitmap;
+                ApplyThumbnailStretch(target);
                 target.Opacity = 1;
                 if (animate)
                 {

--- a/src/OddSnap/UI/Settings/SettingsWindow.Appearance.cs
+++ b/src/OddSnap/UI/Settings/SettingsWindow.Appearance.cs
@@ -151,6 +151,7 @@ public partial class SettingsWindow
         AutoIndexImagesCheck.IsChecked = s.AutoIndexImages;
         MuteSoundsCheck.IsChecked = s.MuteSounds;
         DisableAnimationsCheck.IsChecked = s.DisableAnimations;
+        RoundedCornersCheck.IsChecked = s.UseRoundedCorners;
         SelectUiScale(s.UiScale);
         OcrAutoCopyCheck.IsChecked = s.OcrAutoCopyToClipboard;
         CrosshairGuidesCheck.IsChecked = s.ShowCrosshairGuides;
@@ -160,8 +161,10 @@ public partial class SettingsWindow
         ShowToolNumberBadgesCheck.IsChecked = s.ShowToolNumberBadges;
         AskFileNameCheck.IsChecked = s.AskForFileNameOnSave;
         MonthlyFoldersCheck.IsChecked = s.SaveInMonthlyFolders;
+        IncludeSourceAppInFileNameCheck.IsChecked = s.IncludeSourceAppInFileName;
         LoadFileNameTemplate(s.FileNameTemplate);
         ToastPositionCombo.SelectedIndex = (int)s.ToastPosition;
+        TrayLeftClickCombo.SelectedIndex = (int)s.TrayLeftClickAction;
         CaptureDockSideCombo.SelectedIndex = (int)s.CaptureDockSide;
         ScrollingCaptureModeCombo.SelectedIndex = Enum.IsDefined(typeof(ScrollingCaptureMode), s.ScrollingCaptureMode)
             ? (int)s.ScrollingCaptureMode

--- a/src/OddSnap/UI/Settings/SettingsWindow.Preferences.cs
+++ b/src/OddSnap/UI/Settings/SettingsWindow.Preferences.cs
@@ -388,6 +388,53 @@ public partial class SettingsWindow
             });
     }
 
+    private void RoundedCornersCheck_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded || _suppressGeneralPreferenceChange) return;
+
+        var previous = _settingsService.Settings.UseRoundedCorners;
+        var enabled = RoundedCornersCheck.IsChecked == true;
+        UpdateGeneralPreference(
+            "settings.rounded-corners",
+            "Rounded corners",
+            previous,
+            enabled,
+            value => _settingsService.Settings.UseRoundedCorners = value,
+            value => RoundedCornersCheck.IsChecked = value,
+            value =>
+            {
+                OddSnapWindowChrome.SetRoundedCornersEnabled(value);
+                // History cards bake their radius in when they are built, so drop the cached cards
+                // and let the current tab rebuild them at the new radius.
+                RebuildHistoryCardsForChromeChange();
+            });
+    }
+
+    private void RebuildHistoryCardsForChromeChange()
+    {
+        foreach (var item in _allHistoryItems.Concat(_allGifItems).Concat(_allStickerItems))
+            ReleaseHistoryCard(item);
+
+        if (HistoryTab.IsChecked == true)
+            LoadCurrentHistoryTab();
+    }
+
+    private void TrayLeftClickCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _suppressGeneralPreferenceChange) return;
+
+        var previous = _settingsService.Settings.TrayLeftClickAction;
+        var selected = (TrayClickAction)Math.Clamp(TrayLeftClickCombo.SelectedIndex, 0, (int)TrayClickAction.Nothing);
+        UpdateGeneralPreference(
+            "settings.tray-left-click",
+            "Tray left click action",
+            previous,
+            selected,
+            value => _settingsService.Settings.TrayLeftClickAction = value,
+            value => TrayLeftClickCombo.SelectedIndex = (int)value,
+            _ => HotkeyChanged?.Invoke());
+    }
+
     private void UiScaleCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (!IsLoaded || _suppressGeneralPreferenceChange) return;

--- a/src/OddSnap/UI/SettingsWindow.xaml
+++ b/src/OddSnap/UI/SettingsWindow.xaml
@@ -390,7 +390,7 @@
         </Style>
 
         <Style x:Key="Card" TargetType="Border">
-            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="CornerRadius" Value="{DynamicResource OddSnapCardCornerRadius}"/>
             <Setter Property="Padding" Value="14,9"/>
             <Setter Property="Margin" Value="0,0,0,10"/>
             <Setter Property="Background" Value="{DynamicResource ThemeCardBrush}"/>
@@ -644,7 +644,7 @@
     </Window.Resources>
 
         <Border Margin="1" CornerRadius="12">
-    <Border x:Name="OuterBorder" CornerRadius="12" ClipToBounds="True"
+    <Border x:Name="OuterBorder" CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" ClipToBounds="True"
             BorderThickness="1">
     <Grid>
         <Grid.RowDefinitions>
@@ -1297,6 +1297,26 @@
                                                Visibility="Collapsed"
                                                Margin="0,6,0,0"/>
                                 </StackPanel>
+                            </Grid>
+                            <Border Height="1" Background="{DynamicResource ThemeSeparatorBrush}" Margin="0,9,0,9"/>
+                            <Grid Style="{StaticResource SettingRow}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource SettingIconFrame}">
+                                    <TextBlock Text="&#xE737;" Style="{StaticResource SettingIconGlyph}"/>
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="Add the source app to file names" Style="{StaticResource SettingTitle}"/>
+                                    <TextBlock Text="Append the app a capture came from (Discord, Task Manager) so files stay searchable. Use the {app} token to place it yourself." Style="{StaticResource SettingDescription}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox x:Name="IncludeSourceAppInFileNameCheck" Grid.Column="2" Content="" FontSize="13" VerticalAlignment="Center"
+                                          ToolTip="Append the app a capture came from to the saved file name"
+                                          AutomationProperties.Name="Add the source app to file names"
+                                          AutomationProperties.HelpText="Append the app a capture came from, such as Discord or Task Manager, to saved capture file names."
+                                          Checked="IncludeSourceAppInFileNameCheck_Changed" Unchecked="IncludeSourceAppInFileNameCheck_Changed"/>
                             </Grid>
                             <Border Height="1" Background="{DynamicResource ThemeSeparatorBrush}" Margin="0,9,0,9"/>
                             <Grid Style="{StaticResource SettingRow}">
@@ -2015,6 +2035,66 @@
                         </Grid>
                     </Border>
 
+                    <TextBlock Text="Tray Icon" Style="{StaticResource SectionLabel}" Margin="4,16,0,9"/>
+                    <Border Style="{StaticResource Card}">
+                        <Grid Style="{StaticResource SettingRow}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource SettingIconFrame}">
+                                <TextBlock Text="&#xE962;" Style="{StaticResource SettingIconGlyph}"/>
+                            </Border>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                <TextBlock Text="Left click action" Style="{StaticResource SettingTitle}"/>
+                                <TextBlock Text="Choose what a left click on the OddSnap tray icon does. Right click always opens the menu." Style="{StaticResource SettingDescription}" TextWrapping="Wrap"/>
+                            </StackPanel>
+                            <ComboBox x:Name="TrayLeftClickCombo" Grid.Column="2" MinWidth="150"
+                                      VerticalAlignment="Center"
+                                      AutomationProperties.Name="Tray icon left click action"
+                                      ToolTip="Choose what a left click on the OddSnap tray icon does."
+                                      SelectionChanged="TrayLeftClickCombo_SelectionChanged">
+                                <ComboBoxItem Content="Screenshot"
+                                              ToolTip="Start a region screenshot."
+                                              AutomationProperties.Name="Screenshot tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon starts a region screenshot."/>
+                                <ComboBoxItem Content="Full screen"
+                                              ToolTip="Capture the whole screen."
+                                              AutomationProperties.Name="Full screen tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon captures the whole screen."/>
+                                <ComboBoxItem Content="Text capture"
+                                              ToolTip="Start a text (OCR) capture."
+                                              AutomationProperties.Name="Text capture tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon starts a text capture."/>
+                                <ComboBoxItem Content="Color picker"
+                                              ToolTip="Open the color picker."
+                                              AutomationProperties.Name="Color picker tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon opens the color picker."/>
+                                <ComboBoxItem Content="Record"
+                                              ToolTip="Start a screen recording."
+                                              AutomationProperties.Name="Record tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon starts a recording."/>
+                                <ComboBoxItem Content="Scroll capture"
+                                              ToolTip="Start a scrolling capture."
+                                              AutomationProperties.Name="Scroll capture tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon starts a scrolling capture."/>
+                                <ComboBoxItem Content="History"
+                                              ToolTip="Open the capture history."
+                                              AutomationProperties.Name="History tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon opens the capture history."/>
+                                <ComboBoxItem Content="Settings"
+                                              ToolTip="Open OddSnap settings."
+                                              AutomationProperties.Name="Settings tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon opens OddSnap settings."/>
+                                <ComboBoxItem Content="Do nothing"
+                                              ToolTip="Ignore left clicks on the tray icon."
+                                              AutomationProperties.Name="Do nothing tray action"
+                                              AutomationProperties.HelpText="Left-clicking the tray icon does nothing."/>
+                            </ComboBox>
+                        </Grid>
+                    </Border>
+
                     <TextBlock Text="Sound &amp; Motion" Style="{StaticResource SectionLabel}"/>
                     <Border Style="{StaticResource Card}">
                         <StackPanel>
@@ -2054,6 +2134,26 @@
                                           AutomationProperties.Name="Disable animations"
                                           ToolTip="Reduce motion effects across the app."
                                           Checked="DisableAnimationsCheck_Changed" Unchecked="DisableAnimationsCheck_Changed"/>
+                            </Grid>
+                            <Border Height="1" Background="{DynamicResource ThemeSeparatorBrush}" Margin="0,9,0,9"/>
+                            <Grid Style="{StaticResource SettingRow}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource SettingIconFrame}">
+                                    <TextBlock Text="&#xE1A5;" Style="{StaticResource SettingIconGlyph}"/>
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="Rounded corners" Style="{StaticResource SettingTitle}"/>
+                                    <TextBlock Text="Round the corners of OddSnap windows, toasts, and cards. Turn off for square, flat chrome." Style="{StaticResource SettingDescription}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox x:Name="RoundedCornersCheck" Grid.Column="2" Content="" FontSize="13" VerticalAlignment="Center"
+                                          AutomationProperties.Name="Rounded corners"
+                                          AutomationProperties.HelpText="Round the corners of OddSnap windows, toasts, and cards."
+                                          ToolTip="Round the corners of OddSnap windows, toasts, and cards."
+                                          Checked="RoundedCornersCheck_Changed" Unchecked="RoundedCornersCheck_Changed"/>
                             </Grid>
                             <Border Height="1" Background="{DynamicResource ThemeSeparatorBrush}" Margin="0,9,0,9"/>
                             <Grid Style="{StaticResource SettingRow}">

--- a/src/OddSnap/UI/SettingsWindow.xaml.cs
+++ b/src/OddSnap/UI/SettingsWindow.xaml.cs
@@ -32,9 +32,14 @@ public partial class SettingsWindow : Window
         ("{w}", "Width"),
         ("{h}", "Height"),
         ("{aspect}", "Aspect"),
+        ("{app}", "Source app"),
         ("{rand}", "Random"),
     ];
     private static readonly SemaphoreSlim ThumbDecodeGate = new(2);
+    private readonly System.Windows.Threading.DispatcherTimer _historyResizeTimer = new()
+    {
+        Interval = TimeSpan.FromMilliseconds(90)
+    };
     private readonly System.Windows.Threading.DispatcherTimer _historyMonitorTimer = new()
     {
         Interval = TimeSpan.FromSeconds(2.5)
@@ -146,10 +151,25 @@ public partial class SettingsWindow : Window
             UpdateLocalEngineUi();
             UpdateUpscaleLocalEngineUi();
         };
+        // A resize drag fires SizeChanged every frame, and each viewport update can rebuild the
+        // whole visible card set when the column count changes. Coalesce them so the drag stays
+        // smooth and the grid settles once the user stops.
+        _historyResizeTimer.Tick += (_, _) =>
+        {
+            _historyResizeTimer.Stop();
+            if (_isClosed || !IsLoaded)
+                return;
+
+            if (HistoryTab.IsChecked == true && HistoryCategoryCombo.SelectedIndex == 0)
+                UpdateVirtualizedHistoryViewport();
+        };
         SizeChanged += (_, _) =>
         {
-            if (IsLoaded && HistoryTab.IsChecked == true && HistoryCategoryCombo.SelectedIndex == 0)
-                UpdateVirtualizedHistoryViewport();
+            if (!IsLoaded || HistoryTab.IsChecked != true || HistoryCategoryCombo.SelectedIndex != 0)
+                return;
+
+            _historyResizeTimer.Stop();
+            _historyResizeTimer.Start();
         };
         Closed += (_, _) =>
         {
@@ -165,6 +185,7 @@ public partial class SettingsWindow : Window
             CancelImageSearchWork();
             _imageIndexRefreshTimer.Stop();
             _historyRefreshTimer.Stop();
+            _historyResizeTimer.Stop();
             _imageSearchDebounceTimer.Stop();
             _ocrSearchDebounceTimer.Stop();
             _ocrSearchDebounceTimer.Tick -= FlushOcrSearchDebounce;
@@ -1026,7 +1047,11 @@ public partial class SettingsWindow : Window
         if (FileNameTemplatePreviewText is null)
             return;
 
-        FileNameTemplatePreviewText.Text = $"Preview: {Helpers.FileNameTemplate.FormatExample(template)}.png";
+        var example = Helpers.FileNameTemplate.FormatExample(
+            template,
+            "Discord",
+            _settingsService.Settings.IncludeSourceAppInFileName);
+        FileNameTemplatePreviewText.Text = $"Preview: {example}.png";
     }
 
     private void LoadFileNameTokenButtons()
@@ -1135,6 +1160,26 @@ public partial class SettingsWindow : Window
             selected,
             value => _settingsService.Settings.SaveInMonthlyFolders = value,
             value => MonthlyFoldersCheck.IsChecked = value);
+    }
+
+    private void IncludeSourceAppInFileNameCheck_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded || _suppressCaptureSavePreferenceChange) return;
+
+        var previous = _settingsService.Settings.IncludeSourceAppInFileName;
+        var selected = IncludeSourceAppInFileNameCheck.IsChecked == true;
+        UpdateCaptureSavePreference(
+            "settings.include-source-app-in-file-name",
+            "Source app in file names",
+            previous,
+            selected,
+            value => _settingsService.Settings.IncludeSourceAppInFileName = value,
+            value =>
+            {
+                IncludeSourceAppInFileNameCheck.IsChecked = value;
+                UpdateFileNameTemplatePreview(_settingsService.Settings.FileNameTemplate);
+            },
+            () => UpdateFileNameTemplatePreview(_settingsService.Settings.FileNameTemplate));
     }
 
     private void BrowseButton_Click(object sender, RoutedEventArgs e)

--- a/src/OddSnap/UI/SetupWizard.xaml
+++ b/src/OddSnap/UI/SetupWizard.xaml
@@ -57,7 +57,7 @@
         <Border.Effect>
             <DropShadowEffect BlurRadius="28" ShadowDepth="4" Opacity="0.5" Color="{DynamicResource WizShadowColor}"/>
         </Border.Effect>
-    <Border x:Name="WizardBorder" CornerRadius="12" ClipToBounds="True"
+    <Border x:Name="WizardBorder" CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" ClipToBounds="True"
             Background="{DynamicResource WizBg}" BorderBrush="{DynamicResource WizBorder}" BorderThickness="1">
     <Grid>
         <Grid.RowDefinitions>

--- a/src/OddSnap/UI/ToastWindow.xaml
+++ b/src/OddSnap/UI/ToastWindow.xaml
@@ -2,11 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         WindowStyle="None"
-        AllowsTransparency="False"
+        AllowsTransparency="True"
         ShowInTaskbar="False"
         Topmost="True"
         ResizeMode="NoResize"
-        Background="#303030"
+        Background="Transparent"
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="Manual"
         UseLayoutRounding="True"
@@ -26,7 +26,7 @@
             </TransformGroup>
         </Border.RenderTransform>
 
-        <Border x:Name="Root" CornerRadius="10" ClipToBounds="True"
+        <Border x:Name="Root" CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" ClipToBounds="True"
                 MaxWidth="360" MinWidth="196"
                 SnapsToDevicePixels="True">
             <Grid>
@@ -42,7 +42,7 @@
                 </Grid.RowDefinitions>
 
                 <Grid x:Name="ImageArea" Grid.Row="0" Visibility="Collapsed" MaxHeight="176" HorizontalAlignment="Center">
-                    <Border x:Name="ImageFrame" CornerRadius="10,10,0,0" ClipToBounds="True">
+                    <Border x:Name="ImageFrame" CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" ClipToBounds="True">
                         <Image x:Name="PreviewImage" Stretch="Uniform"
                                UseLayoutRounding="True"
                                SnapsToDevicePixels="True"
@@ -203,7 +203,7 @@
             <Border x:Name="ShellStroke"
                     Grid.RowSpan="2"
                     Margin="0"
-                    CornerRadius="10"
+                    CornerRadius="{DynamicResource OddSnapWindowCornerRadius}"
                     Background="Transparent"
                     BorderThickness="0"
                     SnapsToDevicePixels="True"

--- a/src/OddSnap/UI/ToastWindow.xaml.cs
+++ b/src/OddSnap/UI/ToastWindow.xaml.cs
@@ -59,37 +59,84 @@ public partial class ToastWindow : Window
     private readonly DispatcherTimer _officeMenuDismissTimer;
     private bool _officeMenuMouseWasDown;
 
+    private const int PreviewMaxWidth = 332;
+    private const int PreviewMaxHeight = 220;
+    private const int PreviewMinWidth = 140;
+    private const int PreviewMinHeight = 56;
+
+    /// <summary>
+    /// The overlay buttons (close/pin/save) are 40px and sit in the toast's corners. A toast sized
+    /// purely to a thin capture leaves them overlapping and unpressable, so these are the smallest
+    /// dimensions that still give the buttons somewhere to live. Below them the toast keeps this
+    /// size and letterboxes the image rather than shrinking around it.
+    /// </summary>
+    private const int PreviewButtonSafeWidth = 152;
+    private const int PreviewButtonSafeHeight = 100;
+
+    /// <summary>Small grabs get scaled up for legibility, but only so far before they turn to mush.</summary>
+    private const double PreviewMaxUpscale = 2.0;
+
+    /// <summary>
+    /// Sizes an image-only toast to the capture's own aspect ratio, so a narrow strip produces a
+    /// narrow toast rather than a letterboxed box. Only genuinely extreme aspect ratios — where
+    /// honouring the ratio would leave an edge a couple of pixels tall — fall back to a framed box.
+    /// </summary>
     internal static (int Width, int Height, bool Framed) ComputeImageOnlyPreviewLayout(int sourceWidth, int sourceHeight)
     {
         int safeWidth = Math.Max(1, sourceWidth);
         int safeHeight = Math.Max(1, sourceHeight);
         double aspect = safeWidth / (double)safeHeight;
-        bool framed = Math.Min(safeWidth, safeHeight) < 72 || aspect > 2.5 || aspect < 0.85;
 
-        if (framed)
+        // Fit inside the maximum box, preserving the aspect ratio.
+        double width = PreviewMaxWidth;
+        double height = width / aspect;
+        if (height > PreviewMaxHeight)
         {
-            if (aspect < 0.85)
-                return (188, 220, true);
-
-            return (280, 176, true);
+            height = PreviewMaxHeight;
+            width = height * aspect;
         }
 
-        const int targetHeight = 188;
-        double width = targetHeight * aspect;
-        double height = targetHeight;
-
-        if (width > 332)
+        // Don't blow a tiny capture up to full toast size.
+        double upscaleCap = Math.Max(1.0, PreviewMaxUpscale);
+        if (width > safeWidth * upscaleCap)
         {
-            width = 332;
+            width = safeWidth * upscaleCap;
             height = width / aspect;
         }
-        else if (width < 188)
+
+        // Grow towards the minimums, but only when the ratio still fits the box.
+        if (width < PreviewMinWidth && PreviewMinWidth / aspect <= PreviewMaxHeight)
         {
-            width = 188;
-            height = Math.Min(targetHeight, width / aspect);
+            width = PreviewMinWidth;
+            height = width / aspect;
         }
 
-        return ((int)Math.Round(width), (int)Math.Round(height), false);
+        if (height < PreviewMinHeight && PreviewMinHeight * aspect <= PreviewMaxWidth)
+        {
+            height = PreviewMinHeight;
+            width = height * aspect;
+        }
+
+        width = Math.Clamp(width, 1, PreviewMaxWidth);
+        height = Math.Clamp(height, 1, PreviewMaxHeight);
+
+        // Pad out to keep the overlay buttons reachable. This is the one case where letterboxing is
+        // the right answer: a strip-shaped toast with no room for its own controls is worse than a
+        // little blank space around the image.
+        bool framed = false;
+        if (width < PreviewButtonSafeWidth)
+        {
+            width = PreviewButtonSafeWidth;
+            framed = true;
+        }
+
+        if (height < PreviewButtonSafeHeight)
+        {
+            height = PreviewButtonSafeHeight;
+            framed = true;
+        }
+
+        return ((int)Math.Round(width), (int)Math.Round(height), framed);
     }
 
     private ToastWindow(ToastSpec spec)
@@ -147,7 +194,10 @@ public partial class ToastWindow : Window
         MouseMove += OnMouseMove;
         MouseLeftButtonUp += OnMouseLeftButtonUp;
         Cursor = System.Windows.Input.Cursors.Hand;
-        SourceInitialized += (_, _) => PopupWindowHelper.ApplyNoActivateChrome(this);
+        SourceInitialized += (_, _) =>
+        {
+            PopupWindowHelper.ApplyNoActivateChrome(this);
+        };
         SizeChanged += (_, _) => UpdateRootClip();
         Loaded += OnLoaded;
     }
@@ -371,7 +421,7 @@ public partial class ToastWindow : Window
             System.Windows.Controls.Grid.SetRowSpan(ImageArea, 2);
             Root.Background = Theme.Brush(Theme.ToastBg);
             ImageFrame.Background = Theme.Brush(Theme.ToastBg);
-            ImageFrame.CornerRadius = new CornerRadius(10);
+            ImageFrame.CornerRadius = OddSnapWindowChrome.RadiusFor(10);
             ImageFrame.BorderThickness = new Thickness(0);
         }
         else
@@ -388,7 +438,9 @@ public partial class ToastWindow : Window
             System.Windows.Controls.Grid.SetRowSpan(ImageArea, 1);
             Root.Background = Theme.Brush(Theme.ToastBg);
             ImageFrame.Background = Theme.Brush(Theme.ToastBg);
-            ImageFrame.CornerRadius = new CornerRadius(10, 10, 0, 0);
+            ImageFrame.CornerRadius = OddSnapWindowChrome.RoundedCornersEnabled
+                ? new CornerRadius(10, 10, 0, 0)
+                : new CornerRadius(0);
             ImageFrame.BorderThickness = new Thickness(0);
         }
 
@@ -1462,10 +1514,15 @@ public partial class ToastWindow : Window
             return;
 
         const double inset = 0.5;
+        // This clip, not Root.CornerRadius, is what actually rounds the toast — including the
+        // bottom corners the progress bar sits in — so it has to honour the setting too.
+        var radius = OddSnapWindowChrome.RoundedCornersEnabled
+            ? Math.Max(0, RootCornerRadius - inset)
+            : 0;
         Root.Clip = new RectangleGeometry(
             new Rect(inset, inset, Math.Max(0, Root.ActualWidth - (inset * 2)), Math.Max(0, Root.ActualHeight - (inset * 2))),
-            Math.Max(0, RootCornerRadius - inset),
-            Math.Max(0, RootCornerRadius - inset));
+            radius,
+            radius);
     }
 
     private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -2131,6 +2188,9 @@ public partial class ToastWindow : Window
         _isFading = false;
         _closeAfterOpacityAnimation = false;
         StopDismissAnimationTimer();
+        BeginAnimation(OpacityProperty, null);
+        SlideTransform.BeginAnimation(TranslateTransform.XProperty, null);
+        SlideTransform.BeginAnimation(TranslateTransform.YProperty, null);
         Opacity = 1;
         Root.Opacity = 1;
         OuterShell.Opacity = 1;
@@ -2172,51 +2232,30 @@ public partial class ToastWindow : Window
         StopDismissAnimationTimer();
         BeginAnimation(LeftProperty, null);
         BeginAnimation(TopProperty, null);
+        BeginAnimation(OpacityProperty, null);
+        SlideTransform.BeginAnimation(TranslateTransform.XProperty, null);
+        SlideTransform.BeginAnimation(TranslateTransform.YProperty, null);
         Opacity = 1;
         Root.Opacity = 1;
         OuterShell.Opacity = 1;
+        SlideTransform.X = 0;
+        SlideTransform.Y = 0;
+
         var dismissToken = _dismissAnimationToken;
         IEasingFunction ease = slide
             ? Motion.SmoothOut
             : Motion.SmoothInOut;
 
         BeginCompositedToastAnimation();
-        if (slide)
-        {
-            var wa = PopupWindowHelper.GetCurrentWorkArea();
-            var (exitLeft, exitTop, animateLeft) = PopupWindowHelper.GetDismissPlacement(
-                _position, ActualWidth, ActualHeight, wa, Edge);
-            if (animateLeft)
-            {
-                BeginAnimation(LeftProperty, new DoubleAnimation
-                {
-                    To = exitLeft,
-                    Duration = duration,
-                    EasingFunction = ease
-                });
-            }
-            else
-            {
-                BeginAnimation(TopProperty, new DoubleAnimation
-                {
-                    To = exitTop,
-                    Duration = duration,
-                    EasingFunction = ease
-                });
-            }
 
-            StartDismissCloseTimer(duration, dismissToken);
-            return;
-        }
-
-        var opacityAnimation = new DoubleAnimation
+        var fadeAnimation = new DoubleAnimation
         {
             To = 0,
             Duration = duration,
             EasingFunction = ease,
             FillBehavior = FillBehavior.HoldEnd
         };
-        opacityAnimation.Completed += (_, _) =>
+        fadeAnimation.Completed += (_, _) =>
         {
             if (dismissToken != _dismissAnimationToken)
                 return;
@@ -2227,7 +2266,44 @@ public partial class ToastWindow : Window
                     DispatcherPriority.Background,
                     "toast.dismiss-close-post");
         };
-        BeginAnimation(OpacityProperty, opacityAnimation);
+
+        if (slide)
+        {
+            // Slide the *content* out inside the window rather than moving the window itself.
+            // Animating Window.Left/Top walked the toast onto the neighbouring monitor on
+            // multi-display setups; translating inside the window clips it at the window edge and
+            // keeps the whole animation on the screen the toast belongs to.
+            var travelX = offsetX == 0 ? 0 : Math.Sign(offsetX) * (ActualWidth + 24);
+            var travelY = offsetY == 0 ? 0 : Math.Sign(offsetY) * (ActualHeight + 24);
+
+            if (travelX != 0)
+            {
+                SlideTransform.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation
+                {
+                    To = travelX,
+                    Duration = duration,
+                    EasingFunction = ease,
+                    FillBehavior = FillBehavior.HoldEnd
+                });
+            }
+
+            if (travelY != 0)
+            {
+                SlideTransform.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation
+                {
+                    To = travelY,
+                    Duration = duration,
+                    EasingFunction = ease,
+                    FillBehavior = FillBehavior.HoldEnd
+                });
+            }
+        }
+
+        BeginAnimation(OpacityProperty, fadeAnimation);
+
+        // Backstop: if the animation is dropped (a theme change or a re-entrant dismiss can clear
+        // it) the Completed handler never runs and the toast would sit on screen forever.
+        StartDismissCloseTimer(duration, dismissToken);
     }
 
     private void StartDismissCloseTimer(TimeSpan duration, int dismissToken)

--- a/src/OddSnap/UI/TrayIcon.cs
+++ b/src/OddSnap/UI/TrayIcon.cs
@@ -41,10 +41,10 @@ public sealed class TrayIcon : IDisposable
         _defaultIcon = CreateDefaultIcon();
         _notifyIcon = new NotifyIcon
         {
-            Text = T("OddSnap - Click to capture, right-click for menu"),
             Icon = _defaultIcon,
             Visible = true
         };
+        SetTrayText(BuildTooltipText());
 
         _notifyIcon.MouseClick += (_, e) => HandleMouseClick(e.Button);
 
@@ -79,20 +79,20 @@ public sealed class TrayIcon : IDisposable
         {
             _recordingIcon ??= CreateRecordingIcon();
             _notifyIcon.Icon = _recordingIcon;
-            _notifyIcon.Text = T("OddSnap recording - click to stop, right-click for menu");
+            SetTrayText(T("OddSnap recording - click to stop, right-click for menu"));
         }
         else
         {
             _notifyIcon.Icon = _defaultIcon;
-            _notifyIcon.Text = T("OddSnap - Click to capture, right-click for menu");
+            SetTrayText(BuildTooltipText());
         }
     }
 
     public void RefreshLocalization()
     {
-        _notifyIcon.Text = _isShowingRecording
+        SetTrayText(_isShowingRecording
             ? T("OddSnap recording - click to stop, right-click for menu")
-            : T("OddSnap - Click to capture, right-click for menu");
+            : BuildTooltipText());
 
         var oldMenu = _menu;
         _menu = CreateThemedMenu();
@@ -160,7 +160,7 @@ public sealed class TrayIcon : IDisposable
         switch (button)
         {
             case MouseButtons.Left:
-                OnCapture?.Invoke();
+                InvokeTrayAction(_settings?.TrayLeftClickAction ?? TrayClickAction.Capture);
                 break;
             case MouseButtons.Middle:
                 OnHistory?.Invoke();
@@ -169,6 +169,63 @@ public sealed class TrayIcon : IDisposable
                 ShowMenu();
                 break;
         }
+    }
+
+    private void InvokeTrayAction(TrayClickAction action)
+    {
+        switch (action)
+        {
+            case TrayClickAction.Capture:
+                OnCapture?.Invoke();
+                break;
+            case TrayClickAction.FullScreen:
+                OnFullScreenCapture?.Invoke();
+                break;
+            case TrayClickAction.TextCapture:
+                OnOcr?.Invoke();
+                break;
+            case TrayClickAction.ColorPicker:
+                OnColorPicker?.Invoke();
+                break;
+            case TrayClickAction.Record:
+                OnGifRecord?.Invoke();
+                break;
+            case TrayClickAction.ScrollCapture:
+                OnScrollCapture?.Invoke();
+                break;
+            case TrayClickAction.History:
+                OnHistory?.Invoke();
+                break;
+            case TrayClickAction.Settings:
+                OnSettings?.Invoke();
+                break;
+            case TrayClickAction.Nothing:
+                break;
+        }
+    }
+
+    private string BuildTooltipText()
+    {
+        var action = _settings?.TrayLeftClickAction ?? TrayClickAction.Capture;
+        var actionLabel = action switch
+        {
+            TrayClickAction.FullScreen => T("OddSnap - Click for a full screen capture, right-click for menu"),
+            TrayClickAction.TextCapture => T("OddSnap - Click for text capture, right-click for menu"),
+            TrayClickAction.ColorPicker => T("OddSnap - Click for the color picker, right-click for menu"),
+            TrayClickAction.Record => T("OddSnap - Click to record, right-click for menu"),
+            TrayClickAction.ScrollCapture => T("OddSnap - Click for scroll capture, right-click for menu"),
+            TrayClickAction.History => T("OddSnap - Click to open history, right-click for menu"),
+            TrayClickAction.Settings => T("OddSnap - Click to open settings, right-click for menu"),
+            TrayClickAction.Nothing => T("OddSnap - Right-click for menu"),
+            _ => T("OddSnap - Click to capture, right-click for menu")
+        };
+        return actionLabel;
+    }
+
+    /// <summary>Shell tray tooltips are capped at 63 characters; translations can overrun that.</summary>
+    private void SetTrayText(string text)
+    {
+        _notifyIcon.Text = text.Length <= 63 ? text : text[..63];
     }
 
     private string? HotkeyHint(string toolId)

--- a/src/OddSnap/UI/UpscaleResultWindow.xaml
+++ b/src/OddSnap/UI/UpscaleResultWindow.xaml
@@ -22,7 +22,7 @@
         <SolidColorBrush x:Key="LoadingTextBrush" Color="#FFFFFFFF"/>
     </Window.Resources>
 
-    <Border x:Name="RootBorder" CornerRadius="12" ClipToBounds="True">
+    <Border x:Name="RootBorder" CornerRadius="{DynamicResource OddSnapWindowCornerRadius}" ClipToBounds="True">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="40"/>


### PR DESCRIPTION
This started as one small feature (a configurable tray click) and grew as I hit
adjacent rough edges while testing it. **It is deliberately easy to carve up — if
you only want some of this, say which parts and I'll split it into separate PRs
or drop the rest.** Each section below is independent apart from the shared
settings plumbing.

Everything was built and exercised against a real desktop, not just compiled.

---

## ⚠️ Behaviour changes to existing users

Two things here change defaults rather than adding opt-in surface. Both are easy
to revert if you'd rather they were opt-in:

1. **`Select` is now pinned to the capture toolbar** (previously it lived in the
   annotation flyout). Rationale in the annotations section below.
2. **The history database gains a `source_app` column.** Added through the
   existing `EnsureColumn` migration path, so older databases upgrade in place
   and nothing else changes.

A third is opt-out rather than opt-in: captures get the source app appended to
their file name by default (`2026-07-27-12-10-13-d703_Discord.png`). There's a
toggle under Capture, but the default changes what new files are called.

---

## Tray icon: configurable left click

Left-clicking the tray icon always started a region screenshot. It's now
configurable under **General → Tray Icon**: screenshot, full screen, text
capture, colour picker, record, scroll capture, history, settings, or nothing.
The tray tooltip describes whichever action is bound. Right click still opens
the menu, middle click still opens history, and a left click during a recording
still stops it.

## Capture source attribution

Saved captures now record which app they came from, so they stay findable later.

The interesting part is *which* app. Using the foreground window is wrong for
region captures — you can drag a selection over a background window without ever
focusing it. So the overlay snapshots the desktop's window z-order before it
opens, and the capture is credited to the topmost window under the selection's
centre (falling back to whichever window covers most of it, ignoring slivers
under 25%). Fullscreen capture falls back to the foreground window;
active-window capture uses that window directly.

When nothing can be attributed — OddSnap's own windows, the shell, the bare
desktop — the capture is left unattributed rather than reusing the last known
app. A stale name would be worse than no name.

The app name lands in three places:

- **File name** — a new `{app}` token, plus an "Add the source app to file names"
  toggle that appends it when your template doesn't already place it.
- **The image itself** — PNG `tEXt` chunks (`Source`, `Software`,
  `Creation Time`) or a JPEG `COM` segment. BMP has no standard slot and is
  skipped.
- **History** — the `source_app` column, surfaced in the new preview window.

## History: right-click actions and an in-app preview

The floating 3-dot button is gone. The same actions are on the card's context
menu, reachable by right click or the keyboard Menu key.

Clicking a screenshot or sticker now opens a fullscreen preview inside OddSnap
instead of handing the file to the system image viewer. It shows the image at
100% when it fits and scaled to fit when it doesn't, over a checkerboard
backdrop. Scroll to zoom, double-click to toggle fit/full size, drag to pan,
arrow keys to move between captures, and click anywhere off the image or press
Escape to close. Video and GIF still open externally, since the system player
handles playback this doesn't.

One detail worth calling out: dismissal completes on mouse **up**, not down.
Closing on the press destroyed the window mid-gesture and let the release fall
through to the history card underneath, which reopened it immediately.

Thumbnails whose shape is far from the card's are now letterboxed instead of
cropped to fill, so a narrow strip shows the whole capture rather than a sliver.
Screen-shaped captures still fill the card.

## Annotations: make editing discoverable

Moving, resizing and deleting annotations already worked — hit-testing, corner
handles, drag-to-move, scale-on-resize and the Delete key are all in
`RegionOverlayForm` today. The problem was purely that you couldn't get to any
of it: the `Select` tool that gates all of it lived in the annotation flyout, and
once something was selected nothing on screen suggested it could be removed.

So: `Select` is pinned to the toolbar, a selected annotation gets an on-screen
delete badge, and Backspace deletes alongside Delete. No changes to the capture
engines themselves.

## Appearance: rounded corners toggle

New **General → Sound & Motion** toggle that squares off OddSnap's chrome —
window roots, title bars and their close button, settings cards, toasts, the
capture preview and history cards. Radii are published as app resources so XAML
picks them up through `DynamicResource`, and open windows re-apply their DWM
corner preference when it flips.

## Toast fixes

Three bugs, all visible with the default settings:

- **Fade-out faded to black.** The toast window was opaque, so animating its
  opacity dissolved the content against its own dark background. It's now
  per-pixel transparent — which `PreviewWindow` already was — so opacity
  genuinely fades it away.
- **Slide-out crossed monitors.** It animated `Window.Left` towards
  `workArea.Right + 20`, which on a multi-monitor desktop is physically *on* the
  next screen, so the toast drove across it. The slide now translates the toast's
  content inside its own window, clipped at the window edge, and eases out with
  a fade.
- **Narrow captures were boxed.** Image-only toasts forced anything outside a
  0.85–2.5 aspect range into a fixed 280×176 frame, so a wide strip appeared
  letterboxed. They now take the capture's own shape, with a floor that keeps the
  overlay buttons reachable and letterboxing reserved for genuine slivers.

## Fixes

- **History upload stuck on "Uploading…".** The card menu flipped its upload item
  to "Uploading…" and disabled it *before* starting the upload, and nothing put
  it back. An upload refused outright — no destination configured, missing
  credentials — left the item stuck and disabled for the rest of the session,
  because cards are cached and reused. It's now driven from real state and
  restored in a `finally`, so a refusal, failure, rate limit or success all leave
  it correct.
- **Resizing with History open stuttered.** Every card reallocated a
  `RectangleGeometry` clip on each drag frame, and the virtualized viewport
  rebuilt the whole visible card set whenever the column count changed. Clip
  geometry is now reused and mutated, row heights only update on real changes,
  and the viewport rebuild is debounced.

---

## Testing

`dotnet build OddSnap.sln` clean, `dotnet test` **326 passing, 34 new**:

- `FileNameTemplateTests` — `{app}` expansion, append-when-absent, no
  duplication when the token is explicit, sanitisation of unsafe characters.
- `CaptureSourceAppTests` — file-name sanitisation, including inputs that
  reduce to nothing.
- `ToastPreviewLayoutTests` — aspect ratio preservation, the toast size box,
  button-safe minimums, and the sliver fallback.

All new tests are pure logic — no windows, no capture, no network, per the
testing rules in `ARCHITECTURE.md`.

Manually exercised on a 3-monitor setup at 125% scaling: capture attribution
across Discord / GitHub Desktop / VS Code, the preview overlay, the rounded
corners toggle, history resize, and the annotation delete badge.

## Notes

- No changes to `site/`, so the committed `docs/` artifact doesn't need
  regenerating.
- The capture engines (`RegionOverlayForm`, recorders, DXGI capture, upload
  engine) are untouched except for the annotation delete badge, per the
  non-goals in `ARCHITECTURE.md`.
- It's one commit because the features share settings plumbing —
  `AppSettings.cs`, `SettingsWindow.xaml` and `SettingsWindow.MediaCard.cs` are
  each touched by several of them, so a themed split would produce commits that
  don't build. Happy to redo it as separate branches if you'd prefer to take
  these piecemeal.
