### PR TITLE
Add a Copy button to the screenshot preview

### DIFF
--- a/src/OddSnap/UI/PreviewWindow.Actions.cs
+++ b/src/OddSnap/UI/PreviewWindow.Actions.cs
@@ -460,6 +460,7 @@ public partial class PreviewWindow
     }
 
     private bool IsPreviewOverlayButtonSource(DependencyObject? source) =>
+        IsChildOf(source, CopyBtn) ||
         IsChildOf(source, CloseBtn) ||
         IsChildOf(source, PinBtn) ||
         IsChildOf(source, SaveBtn);
@@ -471,6 +472,62 @@ public partial class PreviewWindow
     }
 
     // ─── Buttons ───────────────────────────────────────────────────
+
+    private void CopyClick(object sender, MouseButtonEventArgs e)
+    {
+        if (!CanActivateMouseControl(sender))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        e.Handled = true;
+        CopyPreviewToClipboard();
+    }
+
+    private void CopyBtn_KeyDown(object sender, WpfKeyEventArgs e)
+    {
+        if (!CanActivateKeyboardControl(sender, e))
+            return;
+
+        e.Handled = true;
+        CopyPreviewToClipboard();
+    }
+
+    private void CopyPreviewToClipboard()
+    {
+        if (_isFading)
+            return;
+
+        try
+        {
+            if (_isGif)
+            {
+                if (!HasSavedPreviewFileOnDisk())
+                    throw new FileNotFoundException("The saved GIF file is no longer on disk.", _savedFilePath);
+
+                ClipboardService.CopyFilesToClipboard(_savedFilePath!);
+                ToastWindow.Show(ToastSpec.Standard("Copied", "GIF copied to clipboard", _savedFilePath) with { SuppressSound = true });
+                return;
+            }
+
+            if (_screenshot is null)
+                throw new InvalidOperationException("No preview image is available to copy.");
+
+            ClipboardService.CopyToClipboard(_screenshot, _savedFilePath);
+            ToastWindow.Show(ToastSpec.Standard("Copied", "Image copied to clipboard", GetExistingPreviewFilePathOrNull()) with { SuppressSound = true });
+        }
+        catch (Exception ex)
+        {
+            var recovery = _isGif
+                ? "Try saving the GIF or copy it from History."
+                : "Try again, or copy the image from History.";
+            ToastWindow.ShowError(
+                "Copy failed",
+                BuildPreviewFailureBody($"OddSnap could not copy this preview. {recovery}", ex.Message),
+                GetExistingPreviewFilePathOrNull());
+        }
+    }
 
     private void CloseClick(object sender, MouseButtonEventArgs e)
     {

--- a/src/OddSnap/UI/PreviewWindow.xaml
+++ b/src/OddSnap/UI/PreviewWindow.xaml
@@ -44,6 +44,21 @@
                            AutomationProperties.HelpText="Screenshot preview."
                            RenderOptions.BitmapScalingMode="HighQuality"/>
 
+                    <Border x:Name="CopyBtn" Width="40" Height="40" CornerRadius="12"
+                            Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Cursor="Hand"
+                            Focusable="True"
+                            MouseLeftButtonDown="CopyClick"
+                            KeyDown="CopyBtn_KeyDown"
+                            HorizontalAlignment="Left" VerticalAlignment="Top"
+                            Margin="8,8,0,0" Opacity="0"
+                            ToolTip="Copy image to clipboard"
+                            AutomationProperties.Name="Copy image"
+                            AutomationProperties.HelpText="Copy this preview image to the clipboard.">
+                        <Image x:Name="CopyIcon" Width="18" Height="18" Stretch="Uniform" Opacity="1"
+                               RenderOptions.BitmapScalingMode="HighQuality"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+
                     <Border x:Name="CloseBtn" Width="40" Height="40" CornerRadius="12"
                             Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Cursor="Hand"
                             Focusable="True"

--- a/src/OddSnap/UI/PreviewWindow.xaml.cs
+++ b/src/OddSnap/UI/PreviewWindow.xaml.cs
@@ -158,6 +158,7 @@ public partial class PreviewWindow : Window
         _fadeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(_duration) };
         _fadeTimer.Tick += (_, _) => { _fadeTimer.Stop(); if (!_isHovered && !_isPinned) AnimateDismiss(); };
 
+        HookOverlayHover(CopyBtn, CopyIcon, "copy");
         HookOverlayHover(CloseBtn, CloseIcon, "close");
         HookOverlayHover(PinBtn, PinIcon, "pin");
         HookOverlayHover(SaveBtn, SaveIcon, "download");
@@ -218,6 +219,7 @@ public partial class PreviewWindow : Window
         Theme.Refresh();
         ImageBorder.BorderBrush = Theme.Brush(System.Windows.Media.Color.FromArgb(188, 255, 255, 255));
         PreviewFrame.Background = Theme.Brush(Theme.BgElevated);
+        ApplyOverlayButtonVisual(CopyBtn, CopyIcon, "copy", active: false);
         ApplyOverlayButtonVisual(CloseBtn, CloseIcon, "close", active: false);
         ApplyOverlayButtonVisual(PinBtn, PinIcon, "pin", active: _isPinned);
         ApplyOverlayButtonVisual(SaveBtn, SaveIcon, "download", active: false);
@@ -229,6 +231,10 @@ public partial class PreviewWindow : Window
         RefreshPreviewWindowTooltip();
         var previewName = _isGif ? "GIF preview" : "Screenshot preview";
         SetPreviewElementAccessibility(ThumbnailImage, previewName, BuildPreviewImageHelpText());
+        RefreshPreviewOverlayButtonAccessibility(
+            CopyBtn,
+            _isGif ? "Copy GIF" : "Copy image",
+            _isGif ? "Copy this GIF file to the clipboard." : "Copy this preview image to the clipboard.");
         RefreshPreviewOverlayButtonAccessibility(CloseBtn, "Close preview", "Close this preview.");
         RefreshPreviewOverlayButtonAccessibility(PinBtn,
             _isPinned ? "Unpin preview" : "Pin preview",
@@ -486,6 +492,7 @@ public partial class PreviewWindow : Window
 
     private void AnimateButtons(double to)
     {
+        CopyBtn.BeginAnimation(OpacityProperty, Motion.To(to, 150, Motion.SmoothOut));
         CloseBtn.BeginAnimation(OpacityProperty, Motion.To(to, 150, Motion.SmoothOut));
         PinBtn.BeginAnimation(OpacityProperty, Motion.To(_isPinned ? 1 : to, 150, Motion.SmoothOut));
         SaveBtn.BeginAnimation(OpacityProperty, Motion.To(to, 150, Motion.SmoothOut));


### PR DESCRIPTION
## Summary
- add a Copy button to the screenshot preview overlay
- copy the current image on demand without enabling automatic clipboard copying
- provide accessible labels, keyboard activation (Enter/Space), GIF handling, and success/error feedback

## Verification
- `dotnet format whitespace OddSnap.sln --verify-no-changes --no-restore`
- `dotnet format style OddSnap.sln --verify-no-changes --severity warn --no-restore`
- `dotnet format analyzers OddSnap.sln --verify-no-changes --severity warn --no-restore`
- `dotnet build OddSnap.sln --no-restore`
- `dotnet test OddSnap.sln --no-build --no-restore`